### PR TITLE
Take over Smart Title Case

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -2535,6 +2535,7 @@
 		{
 			"name": "Smart Title Case",
 			"details": "https://github.com/braver/SmartTitleCase",
+			"author": ["mattstevens", "braver"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/s.json
+++ b/repository/s.json
@@ -2534,7 +2534,7 @@
 		},
 		{
 			"name": "Smart Title Case",
-			"details": "https://github.com/mattstevens/sublime-titlecase",
+			"details": "https://github.com/braver/SmartTitleCase",
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is an updated fork of Smart Title Case originally by @mattstevens. That repo hasn't been updated in 14 years and has various outstanding issues and PR's, including mine which updates it for python 3.14: https://github.com/mattstevens/sublime-titlecase/pull/6