### PR TITLE
Add Assembly 6801-6301-68HC11 package

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2034,6 +2034,17 @@
 			]
 		},
 		{
+			"name": "Assembly 6801-6301-68HC11",
+			"details": "https://github.com/raparici/sublime-assembly-6801-6303-68hc11",
+			"labels": ["syntax","assembly", "6801", "6803", "HD6301", "HD6303", "68HC11"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Assembly 6809 and 6309 Syntax Highlighting",
 			"details": "https://github.com/dougmasten/sublime-assembly-6809",
 			"labels": ["language syntax"],


### PR DESCRIPTION
   - [x] I'm the package's author and/or maintainer.
   - [x] I have read [the docs][1].
   - [x] I have tagged a release with a [semver][2] version number (v1.0.0).
   - [x] My package repo has a description and a README describing what it's for and how to use it.
   - [x] My package doesn't add context menu entries.
   - [x] My package doesn't add key bindings.
   - [x] Any commands are available via the command palette (Syntax selection).
   - [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and
     open in split view.
   - [x] If my package is a syntax it doesn't also add a color scheme.
   - [x] I use [.gitattributes][3] to exclude files from the package: images, test files,
     sublime-project/workspace.

  My package is...
  A syntax highlighting package for Motorola 6801, Hitachi 6301/6303, and Motorola 68HC11 Assembly
  languages. It provides comprehensive support for mnemonics, directives, and addressing modes for
  these classic microcontrollers.

  There are no packages like it in Package Control.
  While there are other Motorola assembly packages (like 6809 or 68000), this one specifically
  targets the 6801/6301/68HC11 instruction sets with modern Sublime Text syntax features and
  extensive test coverage.