### PR TITLE
Add BladeFormatter entry to b.json

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -1015,7 +1015,7 @@
 			"details": "https://github.com/RushabhJoshi/BladeFormatter",
 			"releases": [
 				{
-					"base": "https://github.com/RushabhJoshi/BladeFormatter",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]

--- a/repository/b.json
+++ b/repository/b.json
@@ -1001,16 +1001,6 @@
 			]
 		},
 		{
-			"name": "BladeFormatter",
-			"details": "https://github.com/RushabhJoshi/BladeFormatter",
-			"releases": [
-				{
-					"base": "https://github.com/RushabhJoshi/BladeFormatter",
-					"tags": true
-				}
-			]
-		},
-		{
 			"name": "Blade Snippets",
 			"details": "https://github.com/dev4dev/blade-snippets",
 			"labels": ["snippets"],
@@ -1027,6 +1017,16 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "BladeFormatter",
+			"details": "https://github.com/RushabhJoshi/BladeFormatter",
+			"releases": [
+				{
+					"base": "https://github.com/RushabhJoshi/BladeFormatter",
 					"tags": true
 				}
 			]

--- a/repository/b.json
+++ b/repository/b.json
@@ -1001,6 +1001,16 @@
 			]
 		},
 		{
+			"name": "BladeFormatter",
+			"details": "https://github.com/RushabhJoshi/BladeFormatter",
+			"releases": [
+				{
+					"base": "https://github.com/RushabhJoshi/BladeFormatter",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Blade Snippets",
 			"details": "https://github.com/dev4dev/blade-snippets",
 			"labels": ["snippets"],

--- a/repository/b.json
+++ b/repository/b.json
@@ -1012,21 +1012,20 @@
 			]
 		},
 		{
-			"name": "Blame Explorer",
-			"details": "https://github.com/gatopeich/sublame",
+			"details": "https://github.com/RushabhJoshi/BladeFormatter",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
+					"base": "https://github.com/RushabhJoshi/BladeFormatter",
 					"tags": true
 				}
 			]
 		},
 		{
-			"name": "BladeFormatter",
-			"details": "https://github.com/RushabhJoshi/BladeFormatter",
+			"name": "Blame Explorer",
+			"details": "https://github.com/gatopeich/sublame",
 			"releases": [
 				{
-					"base": "https://github.com/RushabhJoshi/BladeFormatter",
+					"sublime_text": ">=3000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

### Package Description

My package is **BladeFormatter**, a Sublime Text package that integrates the popular global NPM binary `blade-formatter` to format Laravel Blade template files. It supports custom indentation sizing, line wrapping, Tailwind CSS class sorting, HTML attribute sorting, and standard PSR formatting options.

### Similar Packages & Distinctiveness

There are no packages like it in Package Control. 

While there are packages for Laravel Blade syntax highlighting (e.g., *Laravel Blade*) and minor spacing tweaks (e.g., *Laravel Blade Spacer* which only formats spaces inside double curly braces `{{ }}`), **BladeFormatter** is the first dedicated, general-purpose formatting engine for Laravel Blade files in the Sublime Text ecosystem.

---

*Note on Key Bindings: The package includes default key bindings `ctrl+alt+f` (Windows/Linux) and `cmd+alt+f` (Mac) as they are standard, highly expected shortcuts for formatters. They are documented clearly in the README and mapped natively to the `blade_format` command.*
