### PR TITLE
Adding Russian stress marks

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -114,6 +114,17 @@
 			]
 		},
 		{
+			"name": "AccentLetters",
+			"details": "https://github.com/CJayM/AccentLetters",
+			"labels": ["utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Accessibility",
 			"details": "https://github.com/Yago/ST3-Accessibility",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is an utility that toggles Russian stress marks (ударение) on selected vowels. It works on both lowercase and uppercase Cyrillic vowels using the combining acute accent (U+0301).

There are no packages like it in Package Control.
