### PR TITLE
Add SettingsUI

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1328,6 +1328,16 @@
 			]
 		},
 		{
+			"name": "SettingsUI",
+			"details": "https://github.com/mfuentesg/settings-ui",
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "SettingSwitcher",
 			"details": "https://github.com/halfmoonvic/SettingSwitcher",
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -1330,6 +1330,8 @@
 		{
 			"name": "SettingsUI",
 			"details": "https://github.com/mfuentesg/settings-ui",
+			"labels": ["settings", "settings-ui"],
+			"author": "mfuentesg",
 			"releases": [
 				{
 					"sublime_text": ">=4000",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. (not a syntax package)
- [ ] I use .gitattributes to exclude files from the package. (will add)

My package is a visual settings editor for Sublime Text 4. It opens a two-pane panel that lets users browse and edit `Preferences.sublime-settings` through typed widgets (toggles, dropdowns, color scheme / theme / font pickers) instead of editing raw JSON.

There are no packages like it in Package Control.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org

<img width="1334" height="944" alt="image" src="https://github.com/user-attachments/assets/e2715601-37e6-4d72-a9f5-0aa79c874d3d" />
<img width="1014" height="931" alt="image" src="https://github.com/user-attachments/assets/fd840675-82e6-4e27-b6cb-0a4ca6efd279" />
<img width="975" height="969" alt="image" src="https://github.com/user-attachments/assets/80924eca-8729-41c7-b5ca-a795df4c35bf" />
