### PR TITLE
Take over BitBake package

### DIFF
--- a/repository/b.json
+++ b/repository/b.json
@@ -918,13 +918,14 @@
 			]
 		},
 		{
-			"name": "Bitbake Syntax",
-			"details": "https://github.com/Driim/bitbake-syntax",
+			"name": "BitBake",
+			"previous_names": ["BitBake Syntax"],
+			"details": "https://github.com/SublimeText/BitBake",
 			"labels": ["language syntax"],
 			"releases": [
 				{
-					"sublime_text": ">3084",
-					"tags": true
+					"sublime_text": ">=3176",
+					"tags": "3176-"
 				}
 			]
 		},


### PR DESCRIPTION
Supersedes #9363

This PR takes ownership of "BitBake Syntax" package and re-targets it to SublimeText organization.

New repository is a complete syntax rewrite, maintaining compatibility with recent stable ST3 builds. It is not considered relevant to support earlier ST3 builds.

It fixes various highlighting issues.

---

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
