### PR TITLE
Add Open All in Browser

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -435,6 +435,17 @@
 			]
 		},
 		{
+			"name": "Open All in Browser",
+			"details": "https://github.com/bogdancstrike/sublime_plugin_open_all_in_browser",
+			"labels": ["productivity", "utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Open DOI",
 			"details": "https://github.com/crazytexer/open_doi",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package, Open All in Browser, opens every URL found in the current selection in the default browser, each in its own tab. It recognises http://, https:// and www. links (bare www. opens over https), opens each unique URL only once, and trims trailing punctuation so links embedded in prose still resolve. It's available from the Command Palette, the Tools menu and the right-click menu, has no dependencies, and does nothing when the selection has no URLs.

My package is similar in name to Open In Browser / OpenInBrowser (which render the current file in a browser) and to Open URL (which opens a single URL under the cursor). However it should still be added because it solves a different task: it opens all URLs in a multi-line selection at once — each in its own ab, de-duplicated — rather than opening one link or previewing a file. This makes it useful for logs, Markdown, config files and link lists.