### PR TITLE
Add OMLX to o.json

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -337,6 +337,17 @@
 			]
 		},
 		{
+		  "name": "OMLX",
+		  "details": "https://github.com/xraid/sublime-omlx",
+		  "labels": ["ai", "llm", "chat", "omlx", "macos", "silicon"],
+		  "releases": [
+		    {
+		      "sublime_text": ">=4050",
+		      "tags": true
+		    }
+		  ]
+		},
+		{
 			"name": "On Save",
 			"details": "https://github.com/wl879/SublimeOnSave/",
 			"releases": [


### PR DESCRIPTION
I'm the package's author and/or maintainer.
I have read [the docs](https://docs.sublimetext.io/guide/package-control/submitting.html).
I have tagged a release with a [semver](https://semver.org/) version number.
My package repo has a description and a README describing what it's for and how to use it.
My package doesn't add context menu entries. *
My package doesn't add key bindings. **
Any commands are available via the command palette.
Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
If my package is a syntax it doesn't also add a color scheme. ***
I use [.gitattributes](https://www.git-scm.com/docs/gitattributes#_export_ignore) to exclude files from the package: images, test files, sublime-project/workspace.