### PR TITLE
Add Claude Code IDE

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1376,6 +1376,17 @@
 			]
 		},
 		{
+			"name": "Claude Code IDE",
+			"details": "https://github.com/Cognisant-llc/sublime-claude-code",
+			"labels": ["ai", "claude", "diff"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Claudette",
 			"details": "https://github.com/barryceelen/Claudette",
 			"labels": ["ai", "claude"],

--- a/repository/c.json
+++ b/repository/c.json
@@ -1398,6 +1398,17 @@
 			]
 		},
 		{
+			"name": "Claude Code IDE",
+			"details": "https://github.com/Cognisant-llc/sublime-claude-code",
+			"labels": ["ai", "claude", "diff"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ClaudeSublime",
 			"details": "https://gitlab.com/petr.jakub/claudesublime",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings. (Suggested bindings ship commented out in the keymap; the diff-review UI is driven by in-view Accept/Reject buttons and the command palette.)
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. (Not a syntax package.)
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a native integration of Claude Code (Anthropic's CLI coding agent) for Sublime Text 4. It implements the same WebSocket/MCP IDE-integration protocol that the official VS Code and JetBrains extensions speak (as documented by the claudecode.nvim project), so the agent gets editor context and the editor gets review control:

- in-editor side-by-side diff review of the agent's proposed edits — accept, reject, or hand-edit before accepting
- live selection / open-tabs / workspace context sharing, and `@`-mention of the current selection
- multiple concurrent Claude Code sessions against one Sublime instance

Protocol core is dependency-free Python 3.8 (unit-tested outside Sublime); the server binds to 127.0.0.1 only, with token auth. Verified end-to-end against the real Claude Code client (0.1.1). It is an unofficial community plugin and the README states the trademark relationship prominently.

My package is similar to Claudette in that both talk to Anthropic models. However it should still be added because Claudette is a chat client inside the editor, while this package integrates the Claude Code agent CLI running in a terminal via its IDE protocol — different tool, different workflow (agentic edits with in-editor review rather than chat).
