### PR TITLE
Add Markdown Chart Preview package

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,30 @@
+## Submitting Markdown Chart Preview
+
+- [x] I am the author and maintainer of the package.
+- [x] I have read the submission docs.
+- [x] I have tagged a SemVer release (`v0.1.0`).
+- [x] The repo has a description and a README describing usage.
+- [x] No context menu entries.
+- [x] No default key bindings. The current `Default (Windows).sublime-keymap` only defines `ctrl+alt+m` for `markdown_chart_preview`; flagging this for review.
+- [x] Commands are available via the command palette.
+- [x] Preferences and keybindings (if any) are listed in the menu and the command palette.
+- [x] Not a syntax / color scheme combo.
+- [x] `.gitattributes` ready for export.
+
+### Package
+
+- **Name**: Markdown Chart Preview
+- **Repository**: https://github.com/wtgg/MarkdownChartPreview
+- **Homepage**: https://github.com/wtgg/MarkdownChartPreview
+- **Release**: https://github.com/wtgg/MarkdownChartPreview/releases/tag/v0.1.0
+- **Author**: `wtgg <wtlit@qq.com>`
+- **Sublime Text**: `>=4075`
+- **Labels**: markdown, preview, mermaid, plantuml, graphviz, math, diagram
+
+### Description
+
+Preview Markdown files with Mermaid, PlantUML, Graphviz, KaTeX math, `[TOC]` and heading anchors in the browser.
+
+### Similar packages
+
+There is no existing Package Control package that previews Markdown with Mermaid / PlantUML / Graphviz / KaTeX / `[TOC]` / heading anchors in the way Markdown Chart Preview does. It complements, not duplicates, packages such as `MarkdownPreview`, `OmniMarkupPreviewer`, `MarkdownLivePreview` by focusing on browser-side rendering of modern technical diagrams and formulas.

--- a/repository/m.json
+++ b/repository/m.json
@@ -618,8 +618,6 @@
 			"author": "wtgg <wtlit@qq.com>",
 			"readme": "https://raw.githubusercontent.com/wtgg/MarkdownChartPreview/master/README.md",
 			"issues": "https://github.com/wtgg/MarkdownChartPreview/issues",
-			"donate": null,
-			"buy": null,
 			"releases": [
 				{
 					"sublime_text": ">=4075",

--- a/repository/m.json
+++ b/repository/m.json
@@ -4,7 +4,9 @@
 		{
 			"name": "M3U Syntax",
 			"details": "https://github.com/sal0max/sublime-m3u",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -15,7 +17,10 @@
 		{
 			"name": "M4Expand",
 			"details": "https://github.com/alextarrell/M4Expand",
-			"labels": ["macro", "text manipulation"],
+			"labels": [
+				"macro",
+				"text manipulation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -26,7 +31,9 @@
 		{
 			"name": "M68k Assembly",
 			"details": "https://github.com/stevenjs/M68k-Assembly",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -39,7 +46,9 @@
 			"author": "David Holton",
 			"description": "Provides MAC-1 syntax support for Sublime Text 3.",
 			"details": "https://github.com/davidholton/mac1-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -51,11 +60,16 @@
 			"name": "MacDictionary",
 			"details": "https://github.com/gh640/SublimeMacDictionary",
 			"author": "Goto Hayato",
-			"labels": ["mac", "dictionary"],
+			"labels": [
+				"mac",
+				"dictionary"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3124",
-					"platforms": ["osx"],
+					"platforms": [
+						"osx"
+					],
 					"tags": true
 				}
 			]
@@ -63,11 +77,18 @@
 		{
 			"name": "MacDown App Menu",
 			"details": "https://github.com/diimdeep/sublime-text-macdown-app-menu",
-			"labels": ["markdown", "preview", "editor", "macdown.app"],
+			"labels": [
+				"markdown",
+				"preview",
+				"editor",
+				"macdown.app"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx"],
+					"platforms": [
+						"osx"
+					],
 					"tags": true
 				}
 			]
@@ -75,7 +96,9 @@
 		{
 			"name": "Mackerel Syntax Highlighting",
 			"details": "https://github.com/Phillip3/mackerel_syntax_highlighting",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -96,7 +119,9 @@
 		{
 			"name": "Madebyphunky Color Scheme",
 			"details": "https://github.com/Phunky/madebyphunky",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -117,7 +142,11 @@
 		{
 			"name": "MagentoBacktraceMessageSyntax",
 			"details": "https://github.com/Magebinary/MagentoBacktraceMessageSyntax",
-			"labels": ["magento", "frontend", "language syntax"],
+			"labels": [
+				"magento",
+				"frontend",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -128,7 +157,11 @@
 		{
 			"name": "MagentoSnippets",
 			"details": "https://github.com/MageFront/MagentoSnippets",
-			"labels": ["snippets", "magento", "frontend"],
+			"labels": [
+				"snippets",
+				"magento",
+				"frontend"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -139,7 +172,12 @@
 		{
 			"name": "MagentoWorkflow",
 			"details": "https://github.com/vovayatsyuk/MagentoWorkflow",
-			"labels": ["magento", "magento automation", "docker magento", "magento cache clean"],
+			"labels": [
+				"magento",
+				"magento automation",
+				"docker magento",
+				"magento cache clean"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -151,7 +189,11 @@
 			"name": "MagerunCommander",
 			"details": "https://github.com/nhduy1985/sublime_mageruncommander",
 			"author": "Dustin Tran",
-			"labels": ["magento", "magerun", "commands"],
+			"labels": [
+				"magento",
+				"magerun",
+				"commands"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -163,7 +205,11 @@
 			"name": "MagicComment",
 			"details": "https://github.com/eiskrenkov/MagicComment",
 			"author": "Egor Iskrenkov",
-			"labels": ["text manipulation", "ruby", "frozen string"],
+			"labels": [
+				"text manipulation",
+				"ruby",
+				"frozen string"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -184,7 +230,10 @@
 		{
 			"name": "MagicPython",
 			"details": "https://github.com/MagicStack/MagicPython",
-			"labels": ["language syntax", "python"],
+			"labels": [
+				"language syntax",
+				"python"
+			],
 			"releases": [
 				{
 					"sublime_text": "<4000",
@@ -195,7 +244,11 @@
 		{
 			"name": "MagicTemplates",
 			"details": "https://github.com/vovayatsyuk/sublime-magic-templates",
-			"labels": ["magento", "php templates", "boilerplate"],
+			"labels": [
+				"magento",
+				"php templates",
+				"boilerplate"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -206,7 +259,10 @@
 		{
 			"name": "Magma",
 			"details": "https://github.com/cjdoris/sublime-magma",
-			"labels": ["language syntax", "magma"],
+			"labels": [
+				"language syntax",
+				"magma"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -217,7 +273,10 @@
 		{
 			"name": "MagmaSnippets",
 			"details": "https://github.com/cjdoris/sublime-magma-snippets",
-			"labels": ["snippets", "magma"],
+			"labels": [
+				"snippets",
+				"magma"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -228,7 +287,10 @@
 		{
 			"name": "Magpie",
 			"details": "https://github.com/Silectis/sublime-magpie",
-			"labels": ["language syntax", "magpie"],
+			"labels": [
+				"language syntax",
+				"magpie"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -239,7 +301,12 @@
 		{
 			"name": "MainThings Color Scheme",
 			"details": "https://github.com/vitalfadeev/MainThings",
-			"labels": ["color scheme", "dark", "dlang", "d"],
+			"labels": [
+				"color scheme",
+				"dark",
+				"dlang",
+				"d"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -250,7 +317,10 @@
 		{
 			"name": "Make Automatic Variables",
 			"details": "https://github.com/roperzh/sublime-make-auto-vars",
-			"labels": ["snippets", "makefile"],
+			"labels": [
+				"snippets",
+				"makefile"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -271,11 +341,17 @@
 		{
 			"name": "Make File Executable",
 			"details": "https://github.com/glutanimate/sublime-make-file-executable",
-			"labels": ["chmod", "permissions"],
+			"labels": [
+				"chmod",
+				"permissions"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["linux", "osx"],
+					"platforms": [
+						"linux",
+						"osx"
+					],
 					"tags": true
 				}
 			]
@@ -292,7 +368,9 @@
 		},
 		{
 			"name": "Makefile Plus",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"details": "https://github.com/Altomare/sublime-makefile-plus",
 			"releases": [
 				{
@@ -304,7 +382,10 @@
 		{
 			"name": "makensis",
 			"details": "https://github.com/idleberg/sublime-makensis",
-			"labels": ["build system", "nsis"],
+			"labels": [
+				"build system",
+				"nsis"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -315,11 +396,18 @@
 		{
 			"name": "MakeTargets",
 			"details": "https://github.com/dusk125/sublime-maketargets",
-			"labels": ["make", "makefile", "target", "build system"],
+			"labels": [
+				"make",
+				"makefile",
+				"target",
+				"build system"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["*"],
+					"platforms": [
+						"*"
+					],
 					"tags": true
 				}
 			]
@@ -327,7 +415,9 @@
 		{
 			"name": "Mako",
 			"details": "https://github.com/marconi/mako-tmbundle",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -338,7 +428,10 @@
 		{
 			"name": "Man Page Support",
 			"details": "https://github.com/carsonoid/sublime_man_page_support",
-			"labels": ["language syntax", "snippets"],
+			"labels": [
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -349,7 +442,12 @@
 		{
 			"name": "Mandoc",
 			"details": "https://codeberg.org/ISSOtm/sublime-mandoc",
-			"labels": ["language syntax", "mandoc", "man", "man page"],
+			"labels": [
+				"language syntax",
+				"mandoc",
+				"man",
+				"man page"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -360,7 +458,9 @@
 		{
 			"name": "ManiaScript",
 			"details": "https://github.com/Anthodev/Sublime-ManiaScript",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -371,7 +471,11 @@
 		{
 			"name": "MantisBT",
 			"details": "https://github.com/vboctor/sublime-mantisbt",
-			"labels": ["mantis", "mantisbt", "bugtracker"],
+			"labels": [
+				"mantis",
+				"mantisbt",
+				"bugtracker"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -382,7 +486,9 @@
 		{
 			"name": "Map Snippets",
 			"details": "https://github.com/newsroomdev/Map-Snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -393,7 +499,12 @@
 		{
 			"name": "Maperitive",
 			"details": "https://github.com/klangfarbe/sublime-maperitive",
-			"labels": ["language syntax", "gis", "osm", "openstreetmap"],
+			"labels": [
+				"language syntax",
+				"gis",
+				"osm",
+				"openstreetmap"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -404,7 +515,9 @@
 		{
 			"name": "MapfileSyntax",
 			"details": "https://github.com/szinggeler/SublimeMapfileSyntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -425,7 +538,9 @@
 		{
 			"name": "MapTool Syntax",
 			"details": "https://github.com/wwmoraes/Sublime-MapTool-Syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -436,7 +551,10 @@
 		{
 			"name": "Mar",
 			"details": "https://github.com/marlanghq/mar-sublime",
-			"labels": ["language syntax", "completions"],
+			"labels": [
+				"language syntax",
+				"completions"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -447,7 +565,9 @@
 		{
 			"name": "Marc Mentat Proc Highlighting",
 			"details": "https://github.com/WesleyPeijnenburg/Marc_Syntax_Support",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3084",
@@ -457,7 +577,9 @@
 		},
 		{
 			"details": "https://github.com/MakiseKurisu/MarieAssembly",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -468,7 +590,10 @@
 		{
 			"name": "Markdeep",
 			"details": "https://github.com/gwenzek/sublime_markdeep",
-			"labels": ["language syntax", "markdeep"],
+			"labels": [
+				"language syntax",
+				"markdeep"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -477,9 +602,37 @@
 			]
 		},
 		{
+			"name": "Markdown Chart Preview",
+			"details": "https://github.com/wtgg/MarkdownChartPreview",
+			"description": "Preview Markdown files with Mermaid, PlantUML, Graphviz, KaTeX math, [TOC] and heading anchors in the browser.",
+			"labels": [
+				"markdown",
+				"preview",
+				"mermaid",
+				"plantuml",
+				"graphviz",
+				"math",
+				"diagram"
+			],
+			"homepage": "https://github.com/wtgg/MarkdownChartPreview",
+			"author": "wtgg",
+			"readme": "https://raw.githubusercontent.com/wtgg/MarkdownChartPreview/master/README.md",
+			"issues": "https://github.com/wtgg/MarkdownChartPreview/issues",
+			"donate": null,
+			"buy": null,
+			"releases": [
+				{
+					"sublime_text": ">=4075",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Markdown Code Blocks",
 			"details": "https://github.com/molnarmark/markdowncodeblocks",
-			"labels": ["markdown"],
+			"labels": [
+				"markdown"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -490,7 +643,9 @@
 		{
 			"name": "Markdown Code Packer",
 			"details": "https://github.com/motine/MarkdownCodePacker",
-			"labels": ["markdown"],
+			"labels": [
+				"markdown"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -501,7 +656,10 @@
 		{
 			"name": "Markdown Extended",
 			"details": "https://github.com/jonschlinkert/sublime-markdown-extended",
-			"labels": ["language syntax", "markdown"],
+			"labels": [
+				"language syntax",
+				"markdown"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -512,7 +670,12 @@
 		{
 			"name": "Markdown HTML Preview",
 			"details": "https://github.com/zeyon/MarkdownHtmlPreview",
-			"labels": ["markdown", "preview", "build system", "html"],
+			"labels": [
+				"markdown",
+				"preview",
+				"build system",
+				"html"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -533,7 +696,11 @@
 		{
 			"name": "Markdown Numbered Headers",
 			"details": "https://github.com/weituotian/md_numbered_headers",
-			"labels": ["markdown", "headers", "numbered headers"],
+			"labels": [
+				"markdown",
+				"headers",
+				"numbered headers"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -554,7 +721,9 @@
 		{
 			"name": "Markdown Table Creator",
 			"details": "https://github.com/yusufb/MarkdownTableCreator",
-			"labels": ["markdown"],
+			"labels": [
+				"markdown"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -566,7 +735,11 @@
 			"name": "Markdown Table Formatter",
 			"details": "https://github.com/bitwiser73/MarkdownTableFormatter",
 			"donate": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=WAQUTBM9K8246",
-			"labels": ["formatting", "text manipulation", "markdown"],
+			"labels": [
+				"formatting",
+				"text manipulation",
+				"markdown"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3121",
@@ -577,7 +750,11 @@
 		{
 			"name": "Markdown Table of Contents",
 			"details": "https://github.com/codeleventh/mdtoc",
-			"labels": ["markdown", "table of contents", "text navigation"],
+			"labels": [
+				"markdown",
+				"table of contents",
+				"text navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4000",
@@ -598,7 +775,11 @@
 		{
 			"name": "Markdown Todo",
 			"details": "https://github.com/groenewege/mdTodo",
-			"labels": ["language syntax", "markdown", "todo"],
+			"labels": [
+				"language syntax",
+				"markdown",
+				"todo"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -609,7 +790,10 @@
 		{
 			"name": "MarkdownAssistant",
 			"details": "https://github.com/code-reaper08/MarkdownAssistant",
-			"labels": ["snippets", "markdown"],
+			"labels": [
+				"snippets",
+				"markdown"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -620,7 +804,9 @@
 		{
 			"name": "MarkdownBuild",
 			"details": "https://github.com/misotomlam/SublimeMarkdownBuild",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -641,7 +827,9 @@
 		{
 			"name": "MarkdownCodeExporter",
 			"details": "https://github.com/SublimeText-Markdown/MarkdownCodeExporter",
-			"labels": ["markdown"],
+			"labels": [
+				"markdown"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -653,7 +841,14 @@
 			"name": "MarkdownEditing",
 			"details": "https://github.com/SublimeText-Markdown/MarkdownEditing",
 			"homepage": "https://sublimetext-markdown.github.io/MarkdownEditing",
-			"labels": ["language syntax", "markdown", "github markdown", "gfm", "multimarkdown", "color scheme"],
+			"labels": [
+				"language syntax",
+				"markdown",
+				"github markdown",
+				"gfm",
+				"multimarkdown",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "2000 - 3175",
@@ -676,7 +871,14 @@
 		{
 			"name": "MarkdownFootnotes",
 			"details": "https://github.com/classicist/MarkdownFootnotes",
-			"labels": ["markdown", "academic markdown", "footnote", "multimarkdown", "insert", "automate"],
+			"labels": [
+				"markdown",
+				"academic markdown",
+				"footnote",
+				"multimarkdown",
+				"insert",
+				"automate"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -686,7 +888,10 @@
 		},
 		{
 			"details": "https://github.com/sekogan/MarkdownLight",
-			"labels": ["language syntax", "markdown"],
+			"labels": [
+				"language syntax",
+				"markdown"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -697,7 +902,11 @@
 		{
 			"name": "MarkdownLink",
 			"details": "https://github.com/unlight/sublime-markdown-link",
-			"labels": ["markdown", "links", "urls"],
+			"labels": [
+				"markdown",
+				"links",
+				"urls"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -708,7 +917,10 @@
 		{
 			"name": "MarkdownLivePreview",
 			"details": "https://github.com/math2001/MarkdownLivePreview",
-			"labels": ["markdown", "preview"],
+			"labels": [
+				"markdown",
+				"preview"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -719,7 +931,11 @@
 		{
 			"name": "MarkdownPreview",
 			"details": "https://github.com/facelessuser/MarkdownPreview",
-			"labels": ["markdown", "preview", "build system"],
+			"labels": [
+				"markdown",
+				"preview",
+				"build system"
+			],
 			"releases": [
 				{
 					"sublime_text": "3000 - 4200",
@@ -733,7 +949,11 @@
 		},
 		{
 			"details": "https://github.com/naokazuterada/MarkdownTOC",
-			"labels": ["markdown", "toc", "table of contents"],
+			"labels": [
+				"markdown",
+				"toc",
+				"table of contents"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -744,11 +964,17 @@
 		{
 			"name": "MarkdownWriter",
 			"details": "https://github.com/vanleo2001/MarkdownWriter",
-			"labels": ["markdown", "html", "converting"],
+			"labels": [
+				"markdown",
+				"html",
+				"converting"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3118",
-					"platforms": ["windows"],
+					"platforms": [
+						"windows"
+					],
 					"tags": true
 				}
 			]
@@ -756,7 +982,12 @@
 		{
 			"name": "Marked App Menu",
 			"details": "https://github.com/icio/sublime-text-marked",
-			"labels": ["markdown", "preview", "build system", "marked.app"],
+			"labels": [
+				"markdown",
+				"preview",
+				"build system",
+				"marked.app"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -766,7 +997,11 @@
 		},
 		{
 			"details": "https://github.com/vwheeler63/MarkerStack",
-			"labels": ["bookmark", "navigation", "marker"],
+			"labels": [
+				"bookmark",
+				"navigation",
+				"marker"
+			],
 			"donate": "https://buymeacoffee.com/vwheeler63",
 			"releases": [
 				{
@@ -788,7 +1023,9 @@
 		{
 			"name": "MarkLogic",
 			"details": "https://github.com/paxtonhare/MarkLogic-Sublime",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -809,7 +1046,9 @@
 		{
 			"name": "Marko",
 			"details": "https://github.com/merwan7/sublime-marko",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -820,7 +1059,9 @@
 		{
 			"name": "MarkPress",
 			"details": "https://github.com/rposbo/sublimemarkpress",
-			"previous_names": ["sublimemarkpress"],
+			"previous_names": [
+				"sublimemarkpress"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -831,7 +1072,11 @@
 		{
 			"name": "MarkSearch",
 			"details": "https://github.com/robertcollier4/MarkSearch",
-			"labels": ["search", "find", "mark"],
+			"labels": [
+				"search",
+				"find",
+				"mark"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -842,7 +1087,12 @@
 		{
 			"name": "MarLant",
 			"details": "https://github.com/retifrav/marlant",
-			"labels": ["subrip", "srt", "subtitles", "language syntax"],
+			"labels": [
+				"subrip",
+				"srt",
+				"subtitles",
+				"language syntax"
+			],
 			"author": "retif",
 			"releases": [
 				{
@@ -865,7 +1115,9 @@
 		{
 			"name": "Mask",
 			"details": "https://github.com/tenbits/sublime-mask",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -875,7 +1127,9 @@
 		},
 		{
 			"details": "https://github.com/MakiseKurisu/MasmAssembly",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -885,7 +1139,9 @@
 		},
 		{
 			"details": "https://github.com/guanghao479/Mason",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -896,7 +1152,10 @@
 		{
 			"name": "Match",
 			"details": "https://github.com/li-vu/st-match",
-			"labels": ["file navigation", "search"],
+			"labels": [
+				"file navigation",
+				"search"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -907,7 +1166,9 @@
 		{
 			"name": "Material Color Scheme",
 			"details": "https://github.com/willsoto/material-color-scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -918,7 +1179,9 @@
 		{
 			"name": "Material Design Lite Selectors Snippets",
 			"details": "https://github.com/radzev1ch/material-design-lite-snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"author": "Aliaksandr Radzevich",
 			"releases": [
 				{
@@ -930,7 +1193,9 @@
 		{
 			"name": "Material Design Lite Snippets",
 			"details": "https://github.com/arindampradhan/material-lite-snippet",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"author": "Arindam Pradhan",
 			"releases": [
 				{
@@ -943,7 +1208,11 @@
 		{
 			"name": "Material Monokai",
 			"details": "https://github.com/hlrossato/material-monokai",
-			"labels": ["color scheme", "material", "monokai"],
+			"labels": [
+				"color scheme",
+				"material",
+				"monokai"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -954,7 +1223,10 @@
 		{
 			"name": "Material Nil",
 			"details": "https://github.com/akalongman/sublimetext-material-nil",
-			"labels": ["theme", "color scheme"],
+			"labels": [
+				"theme",
+				"color scheme"
+			],
 			"author": "Avtandil Kikabidze aka LONGMAN",
 			"releases": [
 				{
@@ -965,9 +1237,17 @@
 		},
 		{
 			"name": "Material Theme",
-			"author": ["equinusocio", "material-theme", "SublimeText"],
+			"author": [
+				"equinusocio",
+				"material-theme",
+				"SublimeText"
+			],
 			"details": "https://github.com/SublimeText/material-theme",
-			"labels": ["theme", "color scheme", "material"],
+			"labels": [
+				"theme",
+				"color scheme",
+				"material"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -978,7 +1258,11 @@
 		{
 			"name": "Materialize",
 			"details": "https://github.com/zyphlar/Materialize",
-			"labels": ["theme", "color scheme", "material"],
+			"labels": [
+				"theme",
+				"color scheme",
+				"material"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -989,7 +1273,11 @@
 		{
 			"name": "Materialize-Appbar",
 			"details": "https://github.com/saadq/Materialize-Appbar",
-			"labels": ["theme", "color scheme", "material"],
+			"labels": [
+				"theme",
+				"color scheme",
+				"material"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1000,7 +1288,11 @@
 		{
 			"name": "Materialize-White-Panels",
 			"details": "https://github.com/saadq/Materialize-White-Panels",
-			"labels": ["theme", "color scheme", "material"],
+			"labels": [
+				"theme",
+				"color scheme",
+				"material"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1011,7 +1303,12 @@
 		{
 			"name": "Materialized CSS Snippets",
 			"details": "https://github.com/ayinloya/materialized-css-snippets",
-			"labels": ["snippets", "css", "materialized", "material"],
+			"labels": [
+				"snippets",
+				"css",
+				"materialized",
+				"material"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1023,7 +1320,13 @@
 			"name": "MaterialUi React Component Snippet Autocomplete",
 			"details": "https://github.com/Pushpamk/materialui-react-component-snippet-autocomplete",
 			"author": "Pushpam Kumar",
-			"labels": ["auto-complete", "snippets", "component", "material", "react"],
+			"labels": [
+				"auto-complete",
+				"snippets",
+				"component",
+				"material",
+				"react"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1034,7 +1337,11 @@
 		{
 			"name": "Math Notes",
 			"details": "https://github.com/LemonPi/math-notes",
-			"labels": ["language syntax", "documentation", "notes"],
+			"labels": [
+				"language syntax",
+				"documentation",
+				"notes"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1045,7 +1352,10 @@
 		{
 			"name": "MathML",
 			"details": "https://github.com/Sensibility/MathML-Sublime-Plugin",
-			"labels": ["language syntax", "mathml"],
+			"labels": [
+				"language syntax",
+				"mathml"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1056,7 +1366,11 @@
 		{
 			"name": "Matlab Completions",
 			"details": "https://github.com/tushortz/Matlab-Completions",
-			"labels": ["auto-complete", "completions", "matlab"],
+			"labels": [
+				"auto-complete",
+				"completions",
+				"matlab"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1066,7 +1380,10 @@
 		},
 		{
 			"details": "https://github.com/joepmoritz/MatlabFilenameAutoComplete",
-			"labels": ["auto-complete", "matlab"],
+			"labels": [
+				"auto-complete",
+				"matlab"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1106,7 +1423,10 @@
 		{
 			"name": "Maude Syntax Highlighting",
 			"details": "https://github.com/jpsikorra/maude_syntax_highlight",
-			"labels": ["maude", "language syntax"],
+			"labels": [
+				"maude",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1139,7 +1459,9 @@
 		},
 		{
 			"details": "https://github.com/justinfx/MayaSublime",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1150,7 +1472,11 @@
 		{
 			"name": "Maybs Quit",
 			"details": "https://github.com/xavi-/sublime-maybs-quit",
-			"labels": ["utilities", "file navigation", "window management"],
+			"labels": [
+				"utilities",
+				"file navigation",
+				"window management"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1161,7 +1487,11 @@
 		{
 			"name": "Maze Syntax",
 			"details": "https://github.com/olls/sublime-maze",
-			"labels": ["auto-complete", "language syntax", "snippets"],
+			"labels": [
+				"auto-complete",
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1173,7 +1503,9 @@
 			"name": "MCA Language",
 			"details": "https://github.com/toxic-spanner/MCA.tmLanguage",
 			"author": "mrfishie",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1184,7 +1516,10 @@
 		{
 			"name": "MCFunction",
 			"details": "https://github.com/AjaxGb/Sublime-MCFunction",
-			"labels": ["language syntax", "minecraft"],
+			"labels": [
+				"language syntax",
+				"minecraft"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1195,7 +1530,10 @@
 		{
 			"name": "MCNP",
 			"details": "https://github.com/SublimeText/MCNP",
-			"labels": ["language syntax", "snippets"],
+			"labels": [
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4107",
@@ -1208,7 +1546,12 @@
 			"description": "Connects to a local Model Context Protocol (MCP) server for AI-powered code generation, review, refactoring, and translation using OpenAI or Gemini.",
 			"author": "David Donohue",
 			"details": "https://github.com/sdirishguy/MCPHelperSublimePlugin",
-			"labels": ["mcp", "ai", "code-generation", "sublime-text"],
+			"labels": [
+				"mcp",
+				"ai",
+				"code-generation",
+				"sublime-text"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4000",
@@ -1219,7 +1562,11 @@
 		{
 			"name": "MCPServer",
 			"details": "https://github.com/benyue1978/sublime-mcp",
-			"labels": ["mcp", "ai", "productivity"],
+			"labels": [
+				"mcp",
+				"ai",
+				"productivity"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4171",
@@ -1230,7 +1577,12 @@
 		{
 			"name": "MCS_Syntax",
 			"details": "https://github.com/bmpenuelas/MCS_Syntax",
-			"labels": ["language syntax", "mcs", "xilinx", "fpga"],
+			"labels": [
+				"language syntax",
+				"mcs",
+				"xilinx",
+				"fpga"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1241,7 +1593,9 @@
 		{
 			"name": "MDL Language",
 			"details": "https://github.com/ardenpm/sublime-mdl-language",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1262,7 +1616,10 @@
 		{
 			"name": "MDN Search Doc",
 			"details": "https://github.com/nucliweb/MDNSearchDoc",
-			"labels": ["doc", "documentation"],
+			"labels": [
+				"doc",
+				"documentation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1273,7 +1630,12 @@
 		{
 			"name": "MDX",
 			"details": "https://github.com/SublimeText/MDX",
-			"labels": ["jsx", "language syntax", "markdown", "mdx"],
+			"labels": [
+				"jsx",
+				"language syntax",
+				"markdown",
+				"mdx"
+			],
 			"releases": [
 				{
 					"sublime_text": "3143 - 3211",
@@ -1296,7 +1658,9 @@
 		{
 			"name": "MediaPlayer",
 			"details": "https://github.com/Monnoroch/SublimePlayer",
-			"labels": ["media"],
+			"labels": [
+				"media"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1306,7 +1670,13 @@
 		},
 		{
 			"details": "https://github.com/tosher/Mediawiker",
-			"labels": ["wiki editor", "mediawiki", "wikipedia editor", "wikipedia", "language syntax"],
+			"labels": [
+				"wiki editor",
+				"mediawiki",
+				"wikipedia editor",
+				"wikipedia",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1317,7 +1687,12 @@
 		{
 			"name": "Meetio Theme",
 			"details": "https://github.com/meetio-theme/sublime-meetio-theme",
-			"labels": ["theme", "color scheme", "light", "dark"],
+			"labels": [
+				"theme",
+				"color scheme",
+				"light",
+				"dark"
+			],
 			"releases": [
 				{
 					"sublime_text": "3179 - 4069",
@@ -1342,7 +1717,9 @@
 		{
 			"name": "Mellanox Syntax Highlighter",
 			"details": "https://github.com/keyboardinterrupt/sublime-mellanox-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1363,7 +1740,10 @@
 		{
 			"name": "Memorize",
 			"details": "https://github.com/ckm2k1/sublime_memorize",
-			"labels": ["call stack", "memory aid"],
+			"labels": [
+				"call stack",
+				"memory aid"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4180",
@@ -1383,7 +1763,10 @@
 		{
 			"name": "Mercurial",
 			"details": "https://github.com/guillermooo/mercurial",
-			"labels": ["vcs", "hg"],
+			"labels": [
+				"vcs",
+				"hg"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1426,7 +1809,15 @@
 			"details": "https://github.com/chinchin96/SublimeText-Merge-Windows",
 			"author": "Chinedu Ezeamuzie",
 			"donate": "https://paypal.me/chinchin96",
-			"labels": ["merge windows", "merge tabs", "group tabs", "join windows", "consolidate windows", "tab management", "manage tabs"],
+			"labels": [
+				"merge windows",
+				"merge tabs",
+				"group tabs",
+				"join windows",
+				"consolidate windows",
+				"tab management",
+				"manage tabs"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1447,7 +1838,11 @@
 		{
 			"name": "Mermaid",
 			"details": "https://github.com/SublimeText/Mermaid",
-			"labels": ["build system", "language syntax", "graph"],
+			"labels": [
+				"build system",
+				"language syntax",
+				"graph"
+			],
 			"releases": [
 				{
 					"sublime_text": "3092 - 4049",
@@ -1462,7 +1857,10 @@
 		{
 			"name": "Meson",
 			"details": "https://github.com/Monochrome-Sauce/sublime-meson",
-			"labels": ["build system", "language syntax"],
+			"labels": [
+				"build system",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4095",
@@ -1473,11 +1871,17 @@
 		{
 			"name": "Messages",
 			"details": "https://github.com/kristoformaynard/SublimeMessages",
-			"labels": ["linting", "tool execution"],
+			"labels": [
+				"linting",
+				"tool execution"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["osx", "linux"],
+					"platforms": [
+						"osx",
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -1485,11 +1889,16 @@
 		{
 			"name": "MessagesPylint",
 			"details": "https://github.com/kristoformaynard/SublimeMessagesPylint",
-			"labels": ["linting"],
+			"labels": [
+				"linting"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["osx", "linux"],
+					"platforms": [
+						"osx",
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -1497,11 +1906,16 @@
 		{
 			"name": "MessagesSublemake",
 			"details": "https://github.com/kristoformaynard/SublimeMessagesSublemake",
-			"labels": ["build system"],
+			"labels": [
+				"build system"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["osx", "linux"],
+					"platforms": [
+						"osx",
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -1509,11 +1923,15 @@
 		{
 			"name": "Meta Substitution",
 			"details": "https://github.com/htch/SublimeMetaSubstitutionPlugin",
-			"labels": ["text manipulation"],
+			"labels": [
+				"text manipulation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx"],
+					"platforms": [
+						"osx"
+					],
 					"tags": true
 				}
 			]
@@ -1531,7 +1949,9 @@
 		{
 			"name": "MetaQuotes (MQL4) Language Package",
 			"details": "https://github.com/currencysecrets/mql4",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1572,7 +1992,12 @@
 		{
 			"name": "Method",
 			"details": "https://github.com/shagabutdinov/sublime-method",
-			"labels": ["sublime-enhanced", "text navigation", "text selection", "text manipulation"],
+			"labels": [
+				"sublime-enhanced",
+				"text navigation",
+				"text selection",
+				"text manipulation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1583,7 +2008,9 @@
 		{
 			"name": "Micro16 Syntax",
 			"details": "https://github.com/hschne/sublime-micro-16",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1594,7 +2021,9 @@
 		{
 			"name": "microbit Build System",
 			"details": "https://github.com/stefanbates/sublime-micro-bit",
-			"labels": ["build system"],
+			"labels": [
+				"build system"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1605,7 +2034,9 @@
 		{
 			"name": "MicroPython Tools",
 			"details": "https://github.com/bisguzar/st3-micropython-tools",
-			"labels": ["micropython"],
+			"labels": [
+				"micropython"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1616,7 +2047,14 @@
 		{
 			"name": "Microsoft Power Query Syntax",
 			"details": "https://github.com/dannysummerlin/PowerQuerySublimeSyntax",
-			"labels": ["language syntax", "query", "excel", "powerbi", "microsoft", "ms"],
+			"labels": [
+				"language syntax",
+				"query",
+				"excel",
+				"powerbi",
+				"microsoft",
+				"ms"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1627,7 +2065,10 @@
 		{
 			"name": "Mika",
 			"details": "https://github.com/kyoto-shift/Mika",
-			"labels": ["mika", "language syntax"],
+			"labels": [
+				"mika",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1638,7 +2079,11 @@
 		{
 			"name": "Miking Syntax Highlighting",
 			"details": "https://github.com/miking-lang/miking-sublime-text",
-			"labels": ["mcore", "miking", "language syntax"],
+			"labels": [
+				"mcore",
+				"miking",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1649,7 +2094,9 @@
 		{
 			"name": "MikrotikScript",
 			"details": "https://github.com/Kentzo/MikrotikScript",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1660,7 +2107,9 @@
 		{
 			"name": "Milotic",
 			"details": "https://github.com/vicky002/Milotic",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1681,7 +2130,9 @@
 		{
 			"name": "Mindustry Assembly",
 			"details": "https://github.com/gigamicro/Mindustry4Sublime",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1713,7 +2164,9 @@
 			"name": "Minify",
 			"details": "https://github.com/tssajo/Minify",
 			"author": "tssajo",
-			"labels": ["minify"],
+			"labels": [
+				"minify"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1735,7 +2188,10 @@
 			"name": "Minify on Save",
 			"details": "https://github.com/eltonvs/sublime-minify-on-save",
 			"author": "eltonvs",
-			"labels": ["automation", "minify"],
+			"labels": [
+				"automation",
+				"minify"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1747,7 +2203,9 @@
 			"name": "Minimal Tabs",
 			"details": "https://github.com/rosvik/sublime-minimal-tabs",
 			"author": "rosvik",
-			"labels": ["theme"],
+			"labels": [
+				"theme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1757,7 +2215,10 @@
 		},
 		{
 			"details": "https://github.com/315234/MinimalFortran",
-			"labels": ["language syntax", "fortran"],
+			"labels": [
+				"language syntax",
+				"fortran"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1768,7 +2229,12 @@
 		{
 			"name": "MiniPy",
 			"details": "https://github.com/vim-zz/MiniPy",
-			"labels": ["minipy", "inline", "engine", "parser"],
+			"labels": [
+				"minipy",
+				"inline",
+				"engine",
+				"parser"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1780,7 +2246,10 @@
 			"name": "Miniscript",
 			"details": "https://github.com/thmour/sublime-miniscript",
 			"author": "Mouratidis Theofilos",
-			"labels": ["miniscript", "language syntax"],
+			"labels": [
+				"miniscript",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1791,7 +2260,9 @@
 		{
 			"name": "Minitest Buddy",
 			"details": "https://github.com/glaucocustodio/minitest-buddy-for-sublime-text",
-			"labels": ["file navigation"],
+			"labels": [
+				"file navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1803,7 +2274,12 @@
 			"name": "MiniZinc Language",
 			"details": "https://github.com/astenmark/sublime-mzn",
 			"author": "Andreas Stenmark",
-			"labels": ["minizinc", "language syntax", "mzn", "build system"],
+			"labels": [
+				"minizinc",
+				"language syntax",
+				"mzn",
+				"build system"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1824,7 +2300,10 @@
 		{
 			"name": "Mint Lang",
 			"details": "https://github.com/Orgmir/mint-sublime-text",
-			"labels": ["language syntax", "snippets"],
+			"labels": [
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1835,7 +2314,10 @@
 		{
 			"name": "Minteresting",
 			"details": "https://github.com/daytonn/Minteresting",
-			"labels": ["theme", "color scheme"],
+			"labels": [
+				"theme",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1846,7 +2328,9 @@
 		{
 			"name": "MIPS Syntax",
 			"details": "https://github.com/contradictioned/mips-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1857,7 +2341,10 @@
 		{
 			"name": "mIRC Scripting Language (Highlighting and Autocomplete)",
 			"details": "https://github.com/eneerge/mIRC-Scripting-Language-for-Sublime-Text",
-			"labels": ["auto-complete", "language syntax"],
+			"labels": [
+				"auto-complete",
+				"language syntax"
+			],
 			"author": "Evan Greene",
 			"releases": [
 				{
@@ -1869,7 +2356,9 @@
 		{
 			"name": "Mirodark Color Scheme",
 			"details": "https://github.com/djjcast/mirodark-st2",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1886,7 +2375,9 @@
 					"tags": true
 				}
 			],
-			"labels": ["build system"]
+			"labels": [
+				"build system"
+			]
 		},
 		{
 			"name": "Missing Palette Commands",
@@ -1905,7 +2396,9 @@
 		{
 			"name": "MissingFindPanelKeys",
 			"details": "https://github.com/mattst/SublimeMissingFindPanelKeys",
-			"labels": ["search"],
+			"labels": [
+				"search"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1916,7 +2409,9 @@
 		{
 			"name": "MIST",
 			"details": "https://github.com/Vizzle/SublimePluginForMIST",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1927,7 +2422,10 @@
 		{
 			"name": "Mistral",
 			"details": "https://github.com/giampierod/mistral-sublime",
-			"labels": ["language syntax", "snippets"],
+			"labels": [
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1938,7 +2436,9 @@
 		{
 			"name": "MIT_Alloy",
 			"details": "https://github.com/corbanmailloux/sublime-mit-alloy",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1949,7 +2449,12 @@
 		{
 			"name": "Mithrilizer",
 			"details": "https://github.com/Bondifrench/Mithrilizer",
-			"labels": ["auto-complete", "snippets", "javascript", "mithril"],
+			"labels": [
+				"auto-complete",
+				"snippets",
+				"javascript",
+				"mithril"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1961,7 +2466,16 @@
 			"name": "Miva IDE",
 			"details": "https://github.com/mghweb/sublime-miva-ide",
 			"author": "Max Hegler",
-			"labels": ["auto-complete", "formatting", "language syntax", "snippets", "miva", "mvt", "mivascript", "miva script"],
+			"labels": [
+				"auto-complete",
+				"formatting",
+				"language syntax",
+				"snippets",
+				"miva",
+				"mvt",
+				"mivascript",
+				"miva script"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1972,7 +2486,11 @@
 		{
 			"name": "MivaScript",
 			"details": "https://github.com/zquintana/SublimeMivaScript",
-			"labels": ["language syntax", "miva script", "miva"],
+			"labels": [
+				"language syntax",
+				"miva script",
+				"miva"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1983,7 +2501,9 @@
 		{
 			"name": "MJML-syntax",
 			"details": "https://github.com/mjmlio/mjml-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1994,7 +2514,15 @@
 		{
 			"name": "MKB",
 			"details": "https://github.com/KeeMeng/MKB-Syntax-Highlighting",
-			"labels": ["auto-complete", "color scheme", "formatting", "language syntax", "linting", "mkb", "minecraft"],
+			"labels": [
+				"auto-complete",
+				"color scheme",
+				"formatting",
+				"language syntax",
+				"linting",
+				"mkb",
+				"minecraft"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2005,7 +2533,11 @@
 		{
 			"name": "MLFi",
 			"details": "https://github.com/li-vu/st-mlfi",
-			"labels": ["language syntax", "mlfi", "csml"],
+			"labels": [
+				"language syntax",
+				"mlfi",
+				"csml"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2016,7 +2548,11 @@
 		{
 			"name": "MLIR TOC",
 			"details": "https://github.com/hockyy/mlir-toc",
-			"labels": ["mlir", "navigation", "text manipulation"],
+			"labels": [
+				"mlir",
+				"navigation",
+				"text manipulation"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4000",
@@ -2037,7 +2573,11 @@
 		{
 			"name": "MobileCaddy",
 			"details": "https://github.com/MobileCaddy/mobilecaddy-sublime-package",
-			"labels": ["snippets", "mobilecaddy", "salesforce"],
+			"labels": [
+				"snippets",
+				"mobilecaddy",
+				"salesforce"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2048,7 +2588,11 @@
 		{
 			"name": "MobileLogReader",
 			"details": "https://github.com/deneb42/SublimeLogReader",
-			"labels": ["language syntax", "formatting", "text manipulation"],
+			"labels": [
+				"language syntax",
+				"formatting",
+				"text manipulation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2059,7 +2603,10 @@
 		{
 			"name": "Mocha Chai CoffeeScript",
 			"details": "https://github.com/octoblu/sublime-text-mocha-coffeescript",
-			"labels": ["language syntax", "snippets"],
+			"labels": [
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2070,7 +2617,9 @@
 		{
 			"name": "Mocha Coffee Snippets",
 			"details": "https://github.com/brianstarke/sublime-coffee-mocha-snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2091,7 +2640,9 @@
 		{
 			"name": "Mocha Snippets",
 			"details": "https://github.com/jfromaniello/sublime-mocha-snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2102,7 +2653,11 @@
 		{
 			"name": "Modelica",
 			"details": "https://github.com/BorisChumichev/modelicaSublimeTextPackage",
-			"labels": ["language syntax", "snippets", "modelica"],
+			"labels": [
+				"language syntax",
+				"snippets",
+				"modelica"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2112,7 +2667,12 @@
 		},
 		{
 			"details": "https://github.com/SublimeText/Modelines",
-			"labels": ["formatting", "syntax", "indention", "modeline"],
+			"labels": [
+				"formatting",
+				"syntax",
+				"indention",
+				"modeline"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -2131,7 +2691,10 @@
 		{
 			"name": "ModernFortran",
 			"details": "https://github.com/eirik-kjonstad/modern-fortran-syntax",
-			"labels": ["language syntax", "fortran"],
+			"labels": [
+				"language syntax",
+				"fortran"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2142,7 +2705,10 @@
 		{
 			"name": "ModernPerl",
 			"details": "https://github.com/Blaizer/ModernPerl-sublime",
-			"labels": ["language syntax", "todo"],
+			"labels": [
+				"language syntax",
+				"todo"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2172,7 +2738,11 @@
 		{
 			"name": "Modula-2 Language Syntax",
 			"details": "https://github.com/harogaston/Sublime-Modula-2",
-			"labels": ["auto complete", "language syntax", "snippets"],
+			"labels": [
+				"auto complete",
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2183,7 +2753,13 @@
 		{
 			"name": "MODX Placeholder Snippets",
 			"details": "https://github.com/mkay/MODX-Placeholders",
-			"labels": ["snippets", "language strings", "placeholders", "resource fields", "system settings"],
+			"labels": [
+				"snippets",
+				"language strings",
+				"placeholders",
+				"resource fields",
+				"system settings"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2193,7 +2769,9 @@
 		},
 		{
 			"details": "https://github.com/Deum1teuli/ModxElements",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2204,7 +2782,14 @@
 		{
 			"name": "MOHAA",
 			"details": "https://github.com/eduzappa18/SublimeMOHAA",
-			"labels": ["completions", "language syntax", "snippets", "mohaa", "scr", "morpheus script"],
+			"labels": [
+				"completions",
+				"language syntax",
+				"snippets",
+				"mohaa",
+				"scr",
+				"morpheus script"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3084",
@@ -2214,7 +2799,9 @@
 		},
 		{
 			"details": "https://github.com/SublimeText/Mojolicious",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2225,7 +2812,9 @@
 		{
 			"name": "molokai",
 			"details": "https://github.com/gerardroche/sublime-molokai",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2236,7 +2825,9 @@
 		{
 			"name": "Monaco",
 			"details": "https://github.com/lightify97/monaco-colorscheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2247,7 +2838,9 @@
 		{
 			"name": "Monarch",
 			"details": "https://github.com/ericmagnuson/Monarch",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2288,7 +2881,9 @@
 		{
 			"name": "Mongomapper Snippets",
 			"details": "https://github.com/heelhook/mongomapper-sublime-text2-snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2299,7 +2894,9 @@
 		{
 			"name": "Monkberry",
 			"details": "https://github.com/monkberry/language-monkberry",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2310,7 +2907,9 @@
 		{
 			"name": "MonkeyC",
 			"details": "https://github.com/pzl/Sublime-MonkeyC",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2321,7 +2920,13 @@
 		{
 			"name": "Monochrome Color Schemes",
 			"details": "https://github.com/kristopherjohnson/MonochromeSublimeText",
-			"labels": ["color scheme", "monochrome", "amber", "green", "blueprint"],
+			"labels": [
+				"color scheme",
+				"monochrome",
+				"amber",
+				"green",
+				"blueprint"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2332,7 +2937,11 @@
 		{
 			"name": "Monocyanide Colorscheme",
 			"details": "https://github.com/Centril/sublime-monocyanide-colorscheme",
-			"labels": ["monokai", "cyanide", "color scheme"],
+			"labels": [
+				"monokai",
+				"cyanide",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2343,7 +2952,11 @@
 		{
 			"name": "Monokai - Spacegray",
 			"details": "https://github.com/pyoio/monokai-spacegray",
-			"labels": ["monokai", "spacegray", "color scheme"],
+			"labels": [
+				"monokai",
+				"spacegray",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2354,7 +2967,10 @@
 		{
 			"name": "Monokai Blueberry Color Scheme",
 			"details": "https://github.com/ctruett/monokai-blueberry",
-			"labels": ["color scheme", "monokai"],
+			"labels": [
+				"color scheme",
+				"monokai"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2365,7 +2981,12 @@
 		{
 			"name": "Monokai Dark",
 			"details": "https://github.com/thatal/Monokai-Dark",
-			"labels": ["monokai", "dark", "color scheme", "seti_ui"],
+			"labels": [
+				"monokai",
+				"dark",
+				"color scheme",
+				"seti_ui"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2376,7 +2997,10 @@
 		{
 			"name": "Monokai Extended",
 			"details": "https://github.com/jonschlinkert/sublime-monokai-extended",
-			"labels": ["color scheme", "monokai"],
+			"labels": [
+				"color scheme",
+				"monokai"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2387,7 +3011,10 @@
 		{
 			"name": "Monokai Gray",
 			"details": "https://github.com/IanWold/MonokaiGray",
-			"labels": ["color scheme", "monokai"],
+			"labels": [
+				"color scheme",
+				"monokai"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2398,7 +3025,10 @@
 		{
 			"name": "Monokai Neue",
 			"details": "https://github.com/josh-kaplan/sublime-monokai-neue",
-			"labels": ["monokai", "color scheme"],
+			"labels": [
+				"monokai",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2409,7 +3039,10 @@
 		{
 			"name": "Monokai Rich",
 			"details": "https://github.com/mmghv/sublime-monokai-rich",
-			"labels": ["monokai", "color scheme"],
+			"labels": [
+				"monokai",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2421,7 +3054,10 @@
 			"name": "Monokai Soft",
 			"details": "https://github.com/ThePythonGuy3/Monokai-Soft",
 			"description": "Light coloured dark Monokai color scheme",
-			"labels": ["color scheme", "monokai"],
+			"labels": [
+				"color scheme",
+				"monokai"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3149",
@@ -2432,7 +3068,10 @@
 		{
 			"name": "Monokai++",
 			"details": "https://github.com/dcasella/monokai-plusplus",
-			"labels": ["monokai", "color scheme"],
+			"labels": [
+				"monokai",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2443,7 +3082,12 @@
 		{
 			"name": "MonokaiC",
 			"details": "https://github.com/avivace/monokaiC",
-			"labels": ["monokai", "color scheme", "markdown", "preview"],
+			"labels": [
+				"monokai",
+				"color scheme",
+				"markdown",
+				"preview"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2454,7 +3098,10 @@
 		{
 			"name": "MonokaiFree",
 			"details": "https://github.com/gerardroche/sublime-monokai-free",
-			"labels": ["monokai", "color scheme"],
+			"labels": [
+				"monokai",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3211",
@@ -2498,7 +3145,9 @@
 		{
 			"name": "MoonBit",
 			"details": "https://github.com/hyrious/moonbit-syntax-highlight",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4000",
@@ -2509,7 +3158,9 @@
 		{
 			"name": "Moonlight",
 			"details": "https://github.com/mauroreisvieira/moonlight-sublime-theme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -2520,7 +3171,9 @@
 		{
 			"name": "MoonScript",
 			"details": "https://github.com/ecornell/Sublime-MoonScript",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -2531,7 +3184,9 @@
 		{
 			"name": "Moonscripty",
 			"details": "https://github.com/szensk/sublmoon",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2542,7 +3197,10 @@
 		{
 			"name": "Mooon Light Theme",
 			"details": "https://github.com/developedby-sam/mooon-light",
-			"labels": ["theme", "color scheme"],
+			"labels": [
+				"theme",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2553,7 +3211,9 @@
 		{
 			"name": "MOOS",
 			"details": "https://github.com/oviquezr/sublime-moos",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2565,7 +3225,9 @@
 			"name": "More Layouts",
 			"details": "https://github.com/unknownuser88/morelayouts",
 			"author": "David Bekoyan",
-			"labels": ["layout"],
+			"labels": [
+				"layout"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2576,7 +3238,10 @@
 		{
 			"name": "More Python Completions",
 			"details": "https://github.com/tushortz/More-Python-Completions",
-			"labels": ["completions", "python"],
+			"labels": [
+				"completions",
+				"python"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2619,7 +3284,10 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["windows", "linux"],
+					"platforms": [
+						"windows",
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -2646,7 +3314,9 @@
 		{
 			"name": "Move By Symbols",
 			"details": "https://github.com/abusalimov/SublimeMoveBySymbols",
-			"labels": ["code navigation"],
+			"labels": [
+				"code navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2703,14 +3373,19 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["linux", "windows"],
+					"platforms": [
+						"linux",
+						"windows"
+					],
 					"tags": true
 				}
 			]
 		},
 		{
 			"details": "https://github.com/bkeller2/Mplus",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2722,7 +3397,15 @@
 			"name": "MpyTool",
 			"author": "Pavel Revak",
 			"details": "https://github.com/pavelrevak/mpytool-sublime",
-			"labels": ["micropython", "mpytool", "embedded", "iot", "esp32", "esp8266", "rp2"],
+			"labels": [
+				"micropython",
+				"mpytool",
+				"embedded",
+				"iot",
+				"esp32",
+				"esp8266",
+				"rp2"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4081",
@@ -2733,7 +3416,9 @@
 		{
 			"name": "Mreq Color Scheme",
 			"details": "https://github.com/mreq/mreq-theme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2747,7 +3432,10 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["osx", "linux"],
+					"platforms": [
+						"osx",
+						"linux"
+					],
 					"branch": "master"
 				}
 			]
@@ -2756,7 +3444,9 @@
 			"name": "MRL syntax highlighting",
 			"details": "https://github.com/Bushikot/mrl-sublime-syntax",
 			"author": "Denis Koshechkin",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2768,11 +3458,15 @@
 			"name": "MSBuild selector",
 			"details": "https://github.com/JohanBaltie/MSBuildSelector",
 			"author": "Johan Baltié",
-			"labels": ["build system"],
+			"labels": [
+				"build system"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["windows"],
+					"platforms": [
+						"windows"
+					],
 					"tags": true
 				}
 			]
@@ -2780,7 +3474,10 @@
 		{
 			"name": "Mscgen",
 			"details": "https://github.com/r-stein/sublime-text-mscgen",
-			"labels": ["language syntax", "build system"],
+			"labels": [
+				"language syntax",
+				"build system"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2811,7 +3508,11 @@
 		{
 			"name": "Multi line paste",
 			"details": "https://github.com/shuky19/MultiLinePaste",
-			"labels": ["text manipulation", "clipboard", "paste"],
+			"labels": [
+				"text manipulation",
+				"clipboard",
+				"paste"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2842,7 +3543,9 @@
 		{
 			"name": "Multibyte Word Separators",
 			"details": "https://github.com/naoyukik/SublimeMultibyteWordSeparators",
-			"labels": ["japanese"],
+			"labels": [
+				"japanese"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2853,7 +3556,9 @@
 		{
 			"name": "Multicommand",
 			"details": "https://github.com/dvcrn/sublime-multicommand",
-			"labels": ["keybinding"],
+			"labels": [
+				"keybinding"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2864,7 +3569,11 @@
 		{
 			"name": "MultiEditUtils",
 			"details": "https://github.com/philippotto/Sublime-MultiEditUtils",
-			"labels": ["text manipulation", "code navigation", "text selection"],
+			"labels": [
+				"text manipulation",
+				"code navigation",
+				"text selection"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2885,7 +3594,9 @@
 		{
 			"name": "MultiLang Color Scheme",
 			"details": "https://github.com/ProjectCleverWeb/MultiLang-Color-Schemes",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2896,7 +3607,11 @@
 		{
 			"name": "MultipleSelectionScroller",
 			"details": "https://github.com/mattst/MultipleSelectionScroller",
-			"labels": ["cursors manipulation", "text navigation", "text selection"],
+			"labels": [
+				"cursors manipulation",
+				"text navigation",
+				"text selection"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2916,7 +3631,11 @@
 		{
 			"name": "MultiValue BASIC",
 			"details": "https://github.com/ianharper/Sublime-Text-MVBasic-Syntax",
-			"labels": ["color scheme", "language syntax", "snippets"],
+			"labels": [
+				"color scheme",
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2927,7 +3646,9 @@
 		{
 			"name": "MUMPS",
 			"details": "https://github.com/ksherlock/MUMPS.tmbundle",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2938,7 +3659,9 @@
 		{
 			"name": "Murphi",
 			"details": "https://bitbucket.org/timlinsc/sublimemurphi",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -2950,7 +3673,9 @@
 			"name": "Mussum Ipsum",
 			"details": "https://github.com/leandrocunha/mussum-ipsum-for-sublime-text",
 			"author": "Leandro Cunha aka. Frango",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -2961,7 +3686,10 @@
 		{
 			"name": "Mustache",
 			"details": "https://github.com/SublimeText/Mustache",
-			"labels": ["language syntax", "snippets"],
+			"labels": [
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "3092 - 4151",
@@ -2976,7 +3704,9 @@
 		{
 			"name": "Mustang Color Scheme",
 			"details": "https://github.com/lyubenblagoev/sublime-mustang-color-scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3027,7 +3757,9 @@
 		{
 			"name": "myPDDL",
 			"details": "https://github.com/Pold87/myPDDL",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3038,7 +3770,13 @@
 		{
 			"name": "MypyReveal",
 			"details": "https://github.com/fortana-co/sublime-mypy-reveal",
-			"labels": ["linting", "mypy", "check", "python", "type"],
+			"labels": [
+				"linting",
+				"mypy",
+				"check",
+				"python",
+				"type"
+			],
 			"author": "kylebebak",
 			"releases": [
 				{
@@ -3050,7 +3788,13 @@
 		{
 			"name": "MySFTP",
 			"details": "https://github.com/icjmaa/MySFTP",
-			"labels": ["ftp", "sftp", "ssh", "free", "open source"],
+			"labels": [
+				"ftp",
+				"sftp",
+				"ssh",
+				"free",
+				"open source"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3061,7 +3805,11 @@
 		{
 			"name": "MySQL Snippets",
 			"details": "https://github.com/korniychuk/sublime-sql-snippets",
-			"labels": ["snippets", "mysql", "sql"],
+			"labels": [
+				"snippets",
+				"mysql",
+				"sql"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/m.json
+++ b/repository/m.json
@@ -615,7 +615,7 @@
 				"diagram"
 			],
 			"homepage": "https://github.com/wtgg/MarkdownChartPreview",
-			"author": "wtgg",
+			"author": "wtgg <wtlit@qq.com>",
 			"readme": "https://raw.githubusercontent.com/wtgg/MarkdownChartPreview/master/README.md",
 			"issues": "https://github.com/wtgg/MarkdownChartPreview/issues",
 			"donate": null,


### PR DESCRIPTION
## Submitting Markdown Chart Preview

- [x] I am the author and maintainer of the package.
- [x] I have read the submission docs.
- [x] I have tagged a SemVer release (`v0.1.0`).
- [x] The repo has a description and a README describing usage.
- [x] No context menu entries.
- [x] No default key bindings. The current `Default (Windows).sublime-keymap` only defines `ctrl+alt+m` for `markdown_chart_preview`; flagging this for review.
- [x] Commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette.
- [x] Not a syntax / color scheme combo.
- [x] `.gitattributes` ready for export.

### Package

- **Name**: Markdown Chart Preview
- **Repository**: https://github.com/wtgg/MarkdownChartPreview
- **Homepage**: https://github.com/wtgg/MarkdownChartPreview
- **Release**: https://github.com/wtgg/MarkdownChartPreview/releases/tag/v0.1.0
- **Author**: `wtgg <wtlit@qq.com>`
- **Sublime Text**: `>=4075`
- **Labels**: markdown, preview, mermaid, plantuml, graphviz, math, diagram

### Description

Preview Markdown files with Mermaid, PlantUML, Graphviz, KaTeX math, `[TOC]` and heading anchors in the browser.

### Similar packages

There is no existing Package Control package that previews Markdown with Mermaid / PlantUML / Graphviz / KaTeX / `[TOC]` / heading anchors in the way Markdown Chart Preview does. It complements, not duplicates, packages such as `MarkdownPreview`, `OmniMarkupPreviewer`, `MarkdownLivePreview` by focusing on browser-side rendering of modern technical diagrams and formulas.
