### PR TITLE
Add ClaudeSublime

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1387,6 +1387,16 @@
 			]
 		},
 		{
+			"name": "ClaudeSublime",
+			"details": "https://gitlab.com/petr.jakub/claudesublime",
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Claudette",
 			"details": "https://github.com/barryceelen/Claudette",
 			"labels": ["ai", "claude"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. *** (not a syntax)
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package, **ClaudeSublime**, runs Claude Code (Anthropic's CLI coding agent) in a
Terminus output panel rooted at the project, and live-highlights the files Claude
edits by tailing its session log. It also offers optional rsync-over-SSH sync of the
project to/from a remote host (macOS/Linux). Docs: https://gitlab.com/petr.jakub/claudesublime

There are no packages like it in Package Control — the closest, *Claudette*, is
unrelated (a color scheme). Existing terminal/sync packages (Terminus, rsync helpers)
each cover only one piece; ClaudeSublime combines an AI-agent panel with change
highlighting derived from the agent's own edit log.

A couple of notes on the checklist:

- **Key bindings:** none are bound by default. The platform keymaps ship every
  shortcut *commented out* as a suggestion, and a "Key Bindings" entry under
  Preferences → Package Settings opens them in split view. Every command is also in
  the Command Palette.
- **Context menu:** I do add a single, nested "ClaudeSublime" submenu to the editor
  and sidebar context menus (not multiple top-level items). All of its commands are
  conditional (`is_enabled`), so they grey out where they don't apply. I kept these
  because the sidebar sync / "add file to context" actions are the natural
  right-click workflow, but I'm happy to adjust if you'd prefer them removed.

Terminus is a runtime dependency; since Package Control can't declare a package (vs.
library) dependency, the plugin detects when Terminus is missing and offers to
install it via Package Control.
