### PR TITLE
Add CompareLive

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -2350,7 +2350,7 @@
 					"tags": true
 				}
 			]
-		},		
+		},
 		{
 			"name": "CodeStats",
 			"details": "https://github.com/code-stats/code-stats-sublime",
@@ -3321,6 +3321,17 @@
 			"releases": [
 				{
 					"sublime_text": ">=3143",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "CompareLive",
+			"details": "https://github.com/mwei-io/CompareLive",
+			"labels": ["diff", "compare", "productivity", "text manipulation", "utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
 					"tags": true
 				}
 			]

--- a/repository/c.json
+++ b/repository/c.json
@@ -3326,7 +3326,6 @@
 			]
 		},
 		{
-			"name": "CompareLive",
 			"details": "https://github.com/mwei-io/CompareLive",
 			"labels": ["diff", "compare", "productivity", "text manipulation", "utilities"],
 			"releases": [


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is CompareLive, a live diff comparison plugin for Sublime Text 4. It opens two tabs side by side in a dedicated two-pane window and refreshes diff highlights in real time as you type, with two-layer line + word-level intraline highlighting, synchronized scrolling, and ghost placeholder lines to keep both sides visually aligned.

Regarding the context menu (*): the package adds a single compact `CompareLive` submenu to the editor context menu and one entry to the tab context menu, since picking "this tab vs. that tab" is inherently a tab/cursor-context action. The entries are conditional: "Compare with Selected Tab" is only visible when at least two tabs are open (`is_visible`), and "End Compare" is only enabled while a compare session is active (`is_enabled`).

My package is similar to Compare Side-By-Side, FileDiffs and CompareBuff. However it should still be added because those packages produce a static diff snapshot, while CompareLive keeps the comparison alive: the diff recomputes and re-highlights on every edit, so you can fix differences on the editable side and watch highlights disappear as the two files converge — no need to re-run the comparison. The dedicated compare window also leaves the original window/layout untouched and restores it when the session ends.

<!-- 
A word about AI use:
Although we use automation, a human will be reviewing your submission. An important part of this is an assessment of the ability and willingness of the human submitting the package (i.e. you) to support it long term. This is therefore primarily a human to human conversation. While you're welcome to use any form of automation, you are expected to participate in this conversation yourself.

*)   If you do need a context menu, make sure the menu applies to the cursor
     context, and the commands are conditional. Space in this menu is limited!
**)  There aren't enough keys for all packages, so you risk overriding those
     of other packages. You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) Syntaxes should work in any color scheme the user chooses.

For bonus points also consider how the review guidelines apply to your package:
https://docs.sublimetext.io/reference/package-control/reviewing.html
-->
