### PR TITLE
Add ClaudeSubagent

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1387,7 +1387,6 @@
 			]
 		},
 		{
-			"name": "ClaudeSubagent",
 			"details": "https://github.com/iulianwebdev/ClaudeSubagent",
 			"labels": ["ai", "claude"],
 			"releases": [

--- a/repository/c.json
+++ b/repository/c.json
@@ -1387,6 +1387,17 @@
 			]
 		},
 		{
+			"name": "ClaudeSubagent",
+			"details": "https://github.com/iulianwebdev/ClaudeSubagent",
+			"labels": ["ai", "claude"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Claudette",
 			"details": "https://github.com/barryceelen/Claudette",
 			"labels": ["ai", "claude"],


### PR DESCRIPTION
Adds **ClaudeSubagent** — run an ad-hoc Claude task against the current file in Sublime Text.

- Repo: https://github.com/iulianwebdev/ClaudeSubagent
- Release tag: `1.0.0` (semver, `tags: true`)
- `sublime_text`: `>=4000` (ST4, Python 3.8 plugin host)
- License: MIT · includes README and messages

It drives the Claude Code CLI, authenticating with the user's own Claude subscription — the package ships no API key or credentials.

Requirements checklist:
- [x] Unique package name
- [x] Public repository with a semver git tag
- [x] README and LICENSE present
- [x] `sublime_text` version selector set
- [x] Entry added alphabetically to `repository/c.json`