### PR TITLE
Update PlainTasks

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -1718,12 +1718,16 @@
 			]
 		},
 		{
-			"details": "https://github.com/aziz/PlainTasks",
+			"details": "https://github.com/SublimeText/PlainTasks",
 			"labels": ["language syntax", "todo", "tasks"],
 			"releases": [
 				{
-					"sublime_text": "*",
-					"branch": "master"
+					"sublime_text": "<3092",
+					"branch": "st2/"
+				},
+				{
+					"sublime_text": ">=3092",
+					"branch": "st3/"
 				}
 			]
 		},

--- a/repository/p.json
+++ b/repository/p.json
@@ -1723,11 +1723,11 @@
 			"releases": [
 				{
 					"sublime_text": "<3092",
-					"branch": "st2/"
+					"tags": "st2/"
 				},
 				{
 					"sublime_text": ">=3092",
-					"branch": "st3/"
+					"tags": "st3/"
 				}
 			]
 		},


### PR DESCRIPTION
This PR registers PlainTasks to be installed from SublimeText organization.

Notes:

- Current state is frozen in st2/1.0.0 tag for backward compatibility with ST2.
- All further changes are currently compatible with ST3 up to latest ST4206.
- A request to transfer ownership or maintenance by SublimeText core community has been filed in April 26 by https://github.com/aziz/PlainTasks/issues/449 without any response at the time of writing this.
- With ST4205+ being available for public review, various fixes are required to maintain compatibility. Those have been implemented in forked repository.

---

<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [ ] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

