### PR TITLE
Add 4 packages: myBasis, myHeaders, myIrix, myTest

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -3037,11 +3037,44 @@
 			]
 		},
 		{
+			"name": "myBasis",
+			"details": "https://gitlab.com/doering-ai-sublime/basis",
+			"labels": ["utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Mybb Template Editor",
 			"details": "https://github.com/ionutvmi/SublimeMybbTplEditor",
 			"releases": [
 				{
 					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "myHeaders",
+			"details": "https://gitlab.com/doering-ai-sublime/headers",
+			"labels": ["utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "myIrix",
+			"details": "https://gitlab.com/doering-ai-sublime/irix",
+			"labels": ["color scheme"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
 					"tags": true
 				}
 			]
@@ -3098,6 +3131,17 @@
 				{
 					"sublime_text": "<3000",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "myTest",
+			"details": "https://gitlab.com/doering-ai-sublime/pytest",
+			"labels": ["utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
 				}
 			]
 		}


### PR DESCRIPTION
This PR adds 4 non-syntax packages by the same author (me); a sibling PR adds my 10 syntax packages. Happy to split further into per-package PRs if preferred. All 4 share the same release setup: public GitLab repos, `v0.7.0` semver tags, protected `v*` tags (Maintainer-only), `.gitattributes` export-ignore, thorough READMEs.

- [x] I'm the packages' author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repos have a description and a README describing what they're for and how to use them.
- [x] My packages don't add context menu entries. *
- [x] My packages don't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://git-scm.com/docs/gitattributes#_export_ignore

The packages:

| Name | Kind | What it is |
| --- | --- | --- |
| myBasis | utilities | Typed infrastructure for Sublime Text 4 plugin development — the shared base my other plugin packages build on. |
| myHeaders | utilities | Standardized hierarchical comment headers: insert, navigate, and fold code by architectonic section headers. |
| myIrix | color scheme | The Irix color palette (Radix-derived) as a Sublime color scheme, generated from the palette's single source of truth. |
| myTest | utilities | The testing half of a two-package Sublime plugin dev stack (with myBasis): run pytest against plugin code from inside Sublime. |

Regarding the only major policy violation I'm aware of: The pascalCase `my` prefix is a personal brand convention shared across the set. I've tried to follow the other rules though, especially around when to include "Sublime" and/or "Syntax". Let me know if it's a serious blocker and I can conform :)