### PR TITLE
Add 10 syntax packages: Kitty, Logfile, Metasyntax, MystMarkdown, myCSV, myLedger, myPython, myRegex, myTaskfile, myYAML

### DIFF
--- a/repository/k.json
+++ b/repository/k.json
@@ -330,6 +330,17 @@
 			]
 		},
 		{
+			"name": "Kitty",
+			"details": "https://gitlab.com/doering-ai-sublime/kitty",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Kivy Language",
 			"details": "https://github.com/ivlevdenis/kivylng",
 			"labels": ["auto-complete", "build system", "language syntax", "snippets"],

--- a/repository/l.json
+++ b/repository/l.json
@@ -1620,6 +1620,17 @@
 			]
 		},
 		{
+			"name": "Logfile",
+			"details": "https://gitlab.com/doering-ai-sublime/logfile",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Logger Snippets",
 			"details": "https://github.com/ssrihari/sublime-logger-snippets",
 			"labels": ["snippets"],

--- a/repository/m.json
+++ b/repository/m.json
@@ -1562,6 +1562,17 @@
 			]
 		},
 		{
+			"name": "Metasyntax",
+			"details": "https://gitlab.com/doering-ai-sublime/metasyntax",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Meteor Autocomplete (TernJS)",
 			"details": "https://github.com/slava/tern-meteor-sublime",
 			"releases": [
@@ -3047,6 +3058,28 @@
 			]
 		},
 		{
+			"name": "myCSV",
+			"details": "https://gitlab.com/doering-ai-sublime/csv",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "myLedger",
+			"details": "https://gitlab.com/doering-ai-sublime/ledger",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "myPDDL",
 			"details": "https://github.com/Pold87/myPDDL",
 			"labels": ["language syntax"],
@@ -3065,6 +3098,28 @@
 			"releases": [
 				{
 					"sublime_text": ">=3084",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "myPython",
+			"details": "https://gitlab.com/doering-ai-sublime/python",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "myRegex",
+			"details": "https://gitlab.com/doering-ai-sublime/regex",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
 					"tags": true
 				}
 			]
@@ -3092,12 +3147,45 @@
 			]
 		},
 		{
+			"name": "MystMarkdown",
+			"details": "https://gitlab.com/doering-ai-sublime/myst",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MySublimeQL",
 			"details": "https://github.com/biannetta/MySublimeQL",
 			"releases": [
 				{
 					"sublime_text": "<3000",
 					"branch": "master"
+				}
+			]
+		},
+		{
+			"name": "myTaskfile",
+			"details": "https://gitlab.com/doering-ai-sublime/taskfile",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
+			"name": "myYAML",
+			"details": "https://gitlab.com/doering-ai-sublime/yaml",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
 				}
 			]
 		}


### PR DESCRIPTION
This PR adds 10 syntax packages by the same author (me); a sibling PR adds my 4 non-syntax packages. Happy to split further into per-package PRs if preferred. All 10 share the same release setup: public GitLab repos, `v0.7.0` semver tags, protected `v*` tags (Maintainer-only), `.gitattributes` export-ignore, thorough READMEs, and syntax fixtures run in CI.

- [x] I'm the packages' author and/or maintainer.
- [x] I have have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repos have a description and a README describing what they're for and how to use them.
- [x] My packages don't add context menu entries. *
- [x] My packages don't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://git-scm.com/docs/gitattributes#_export_ignore

The packages:

| Name | What it is |
| --- | --- |
| Kitty | Syntax for the kitty terminal's `kitty.conf` — comments, booleans, fonts, colors, key/mouse mappings, `include` — built to make large kitty configs navigable. |
| Logfile | Best-effort syntax for general unix logs (`/var/log`, `journalctl` output): timestamps, log levels, PIDs, hosts, common structural patterns, without being tied to one daemon's format. |
| Metasyntax | Ground-up reimplementation of Sublime's own `.sublime-syntax` definition highlighting, with full context/meta scoping for tooling built on scopes. |
| MystMarkdown | Syntax highlighting for MyST-flavored Markdown (directives, roles, fences, frontmatter), extending the default Markdown syntax. |
| myCSV | Extension of Sublime's built-in CSV support — richer delimiter/dialect handling and scoped fields for tooling. |
| myLedger | Syntax for Ledger/hledger plain-text accounting journals. |
| myPython | Small extension of the default Python syntax (extra scopes used by my tooling), layered on Default/Python. |
| myRegex | Syntax for Matthew Barnett's `regex`-module flavor (inline flags, named groups, recursion, etc.). |
| myTaskfile | Syntax for Task (taskfile.dev) Taskfiles, extending YAML with task/dependency/command constructs. |
| myYAML | Extensions of default YAML: a `yamlfmt` middleman handling `%YAML 1.2` documents, plus experimental YAML-subtype syntaxes (YAMLPath, BashYAML). Experimental, released early — see README. |

Similar packages: myCSV overlaps with `Advanced CSV`, `CSV`, and `rainbow_csv`; it should still be added because it extends ST4's built-in CSV syntax rather than replacing it, and its scopes are designed for downstream tooling. The other 9 have no close equivalents in Package Control. The `my` prefix is a personal brand convention shared across the set (cf. existing `myPDDL`); all names are unique in the channel.
