### PR TITLE
Google Spell Check: point at master, drop ST2 release

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1527,11 +1527,7 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"branch": "st3"
-				},
-				{
-					"sublime_text": "<3000",
-					"branch": "st2"
+					"branch": "master"
 				}
 			]
 		},


### PR DESCRIPTION
Maintainer of [Google Spell Check](https://github.com/noahcoad/google-spell-check) here.

The package has been rewritten for Python 3 and now lives on `master`. This updates the release to track `master` and drops the ST2 entry.

**Why:** the old implementation scraped the Google search results page for the "Did you mean" / "Showing results for" markup. Google removed that markup, so the regex never matched and the plugin silently stopped correcting anything. The rewrite uses Google's suggest endpoint instead, which returns explicit spell-correction metadata, so it only replaces text when Google actually flags a misspelling.

The ST2 version is no longer maintained, so its `<3000` release is dropped rather than repointed.

`master` and the retired `st3` branch currently have identical trees, so this change is a no-op for existing ST3+ installs — it just lets me delete the legacy branches. `repository/g.json` still parses as valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)