### PR TITLE
Add Semble plugin to s.json

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -1077,6 +1077,17 @@
 			]
 		},
 		{
+			"name": "Semble",
+			"details": "https://github.com/debjan/sublime-semble",
+			"labels": ["commands", "utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=4050",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Semi",
 			"details": "https://github.com/yyx990803/semi-sublime",
 			"labels": ["text manipulation"],


### PR DESCRIPTION
Added Semble plugin with details and release information.

<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is plugin that integrates the [semble](https://github.com/MinishLab/semble) CLI tool for semantic code search and related-code discovery directly in editor.

There are no packages like it in Package Control.