### PR TITLE
Route legacy OpenAI completion builds through prefixed tags

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -695,8 +695,12 @@
 			"donate": "https://github.com/sponsors/yaroslavyaroslav",
 			"releases": [
 				{
-					"sublime_text": ">=4050",
+					"sublime_text": "4050 - 4204",
 					"tags": true
+				},
+				{
+					"sublime_text": ">=4205",
+					"tags": "py314-"
 				}
 			]
 		},

--- a/repository/o.json
+++ b/repository/o.json
@@ -696,7 +696,7 @@
 			"releases": [
 				{
 					"sublime_text": "4050 - 4204",
-					"branch": "python-3.8"
+					"tags": "py38-"
 				},
 				{
 					"sublime_text": ">=4205",

--- a/repository/o.json
+++ b/repository/o.json
@@ -695,7 +695,7 @@
 			"donate": "https://github.com/sponsors/yaroslavyaroslav",
 			"releases": [
 				{
-					"sublime_text": "4050 - 4204",
+					"sublime_text": ">=4050",
 					"tags": true
 				},
 				{

--- a/repository/o.json
+++ b/repository/o.json
@@ -695,12 +695,12 @@
 			"donate": "https://github.com/sponsors/yaroslavyaroslav",
 			"releases": [
 				{
-					"sublime_text": ">=4050",
-					"tags": true
+					"sublime_text": "4050 - 4204",
+					"branch": "python-3.8"
 				},
 				{
 					"sublime_text": ">=4205",
-					"tags": "py314-"
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
## What changed

Split OpenAI completion releases by Sublime Text's plugin-host runtime:

- builds 4050–4204 use tags prefixed with `py38-`
- builds 4205+ use regular, unprefixed release tags

The legacy `py38-6.1.0` tag points to the existing 6.1.0 release commit (`f7ed5211bad22942ed13162e87ac07ede37f5d95`).

## Why

Sublime Text 4205 replaces the Python 3.8 plugin host with Python 3.14. Prefixed tags keep the legacy package line fixed while allowing new releases to retain the normal `6.2.0`, `6.3.0`, … tag format.

The release sources do not overlap:

- 4050–4204: `py38-*` tags
- 4205+: unprefixed tags

## Validation

- `uv run pytest -q`: 33 passed
- `uv run -m tools.format_package_control_channel repository/o.json --check`
- parsed `repository/o.json` with `python3 -m json.tool`
- verified Package Control's current prefix selector maps `py38-6.1.0` to version `6.1.0` and excludes prefixed tags from the unprefixed source
