### PR TITLE
Add AhuAIComplete

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -561,6 +561,19 @@
 			]
 		},
 		{
+  			"name": "AhuAIComplete",
+  			"description": "Inline AI ghost-text completion for Sublime Text (Ollama / OpenAI / FIM).",
+  			"author": "ahu",
+  			"details": "https://github.com/ahu/AIComplete",
+  			"labels": ["auto-complete", "completions", "ai", "ghost text"],
+  			"releases": [
+  				{ 
+  					"sublime_text": ">=4000", 
+  					"tags": true 
+  				}
+  			]
+		},
+		{
 			"name": "AI Bridge",
 			"author": "Jonathan Heintzeman",
 			"details": "https://github.com/MNU-497/Sublime-AI-Bridge",

--- a/repository/a.json
+++ b/repository/a.json
@@ -561,17 +561,16 @@
 			]
 		},
 		{
-  			"name": "AhuAIComplete",
-  			"description": "Inline AI ghost-text completion for Sublime Text (Ollama / OpenAI / FIM).",
-  			"author": "ahu",
-  			"details": "https://github.com/ahu/AIComplete",
-  			"labels": ["auto-complete", "completions", "ai", "ghost text"],
-  			"releases": [
-  				{ 
-  					"sublime_text": ">=4000", 
-  					"tags": true 
-  				}
-  			]
+			"name": "AhuAIComplete",
+			"description": "Inline AI ghost-text completion for Sublime Text (Ollama / OpenAI / FIM).",
+			"details": "https://github.com/ahu/AIComplete",
+			"labels": ["auto-complete", "completions", "ai", "ghost text"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
 		},
 		{
 			"name": "AI Bridge",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package: tests, demo.py, install.sh, sublime-project/workspace.

** Note:** AhuAIComplete intentionally provides default key bindings for triggering, cycling and accepting ghost-text completions. They are documented in the README and can be overridden by users via Sublime Text's key bindings preferences.

My package is an inline AI ghost-text code completion plugin for Sublime Text 4. It displays grey ghost-text suggestions as the user types, supports multiple providers (Ollama, OpenAI, OpenAI-compatible FIM), and allows cycling through candidates and partial acceptance.

There are no packages like it in Package Control.
