### PR TITLE
Add NBMEcalc

### DIFF
--- a/repository/n.json
+++ b/repository/n.json
@@ -174,6 +174,16 @@
 			]
 		},
 		{
+			"name": "NBMEcalc",
+			"details": "https://github.com/jiankn/nbmecalc-sublime",
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/ssddanbrown/Nbspr",
 			"releases": [
 				{


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer (submitted for maintainer `jiankn`; this update was prepared with coding-agent assistance).
- [x] I have read [the docs][1] (reviewed for this update).
- [x] I have tagged a release with a [semver][2] version number: `0.1.1`.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view. Not applicable: neither is provided.
- [x] If my package is a syntax it doesn't also add a color scheme. Not applicable: this is a command package.
- [x] I use [.gitattributes][3] to exclude development files from the package: tests, CI, and Git configuration.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package converts a selected practice-assessment input in a text worksheet into an offline educational estimate. Select `free120 76`, run **NBMEcalc: Convert Selected Assessment**, and the selection becomes `249`. The edit is undoable; the command makes no network requests. The README explains that these are independent model assumptions, not official examination conversions or guaranteed results.

The package is similar in interaction to selection-based calculators, but parses specific assessment sources and optional step/form fields used in these study worksheets. It adds no menus or default shortcuts and has no third-party dependencies.

## Review fixes in 0.1.1

The automated review reported an import of a root-level plugin module. Shared helpers now live in `lib/core.py`, with `lib/__init__.py`, and the command imports `.lib.core`. The old root-level helper has been removed. A package-qualified loading test exercises the import and command conversion, alongside the four existing conversion tests. All five tests pass locally on Python 3.13. The release archive was checked to contain the helper subpackage and exclude tests and CI files.

Source: https://github.com/jiankn/nbmecalc-sublime

Release tag: https://github.com/jiankn/nbmecalc-sublime/tree/0.1.1

This description and code repair were prepared with coding-agent assistance. They do not claim a manual Sublime Text GUI test or a personal maintainer response.
