### PR TITLE
Add SubMerge

### DIFF
--- a/repository/s.json
+++ b/repository/s.json
@@ -5213,7 +5213,6 @@
 			]
 		},
 		{
-			"name": "SubMerge",
 			"details": "https://github.com/stuffam/SubMerge",
 			"labels": ["diff", "merge", "diff/merge", "compare", "file management"],
 			"releases": [

--- a/repository/s.json
+++ b/repository/s.json
@@ -5213,6 +5213,17 @@
 			]
 		},
 		{
+			"name": "SubMerge",
+			"details": "https://github.com/stuffam/SubMerge",
+			"labels": ["diff", "merge", "diff/merge", "compare", "file management"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/facelessuser/SubNotify",
 			"releases": [
 				{


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. *** (not a syntax package)
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a file and folder comparison tool that runs inside Sublime Text, in the spirit of WinMerge or Beyond Compare. It shows two or three files side by side, highlights added, changed, and moved lines, and lets you copy individual differences — or all of them — from one pane to another. It also compares whole folder trees, reports file metadata differences (size, dates, permissions), and can render CSV/TSV files as aligned tables before comparing them.

`sublime_text` is `>=4107` because the package requires the Python 3.8 plugin host via `.python-version`, which arrived in that build.

### On the two unchecked boxes

**Context menu entries.** The editor context menu adds a single collapsed `SubMerge` submenu, not a set of top-level items. The tab context menu and the sidebar menu do add entries at the top level — comparison is inherently a "pick these two things" operation, and those are the two places a user selects files. I'm happy to collapse either into a submenu if you'd prefer.

**Key bindings.** As of v1.1.3 the package claims no key globally. Every binding that is active by default is gated on a SubMerge context (`submerge_active`, `submerge_folder_view`, or `submerge_has_marked`), so outside a comparison those keys behave exactly as they did before installing. The five commands that *start* a comparison can't be gated — there's no comparison yet to test for — so they ship commented out with a suggested combination, and the README documents how to enable them. Every one of them is on the Command Palette, so nothing is reachable only by shortcut.

### Similar packages

The closest existing package is [Compare Side-By-Side](https://packagecontrol.io/packages/Compare%20Side-By-Side), which does two-pane text comparison with aligned lines, intra-line highlighting, and synchronised scrolling. SubMerge overlaps with it there and differs in scope: three-way comparison, whole-folder comparison, file-metadata comparison, a CSV/TSV table view, moved-line detection, and copying changes between panes rather than only displaying them. `BeyondCompare` and similar packages shell out to an external diff tool; SubMerge does the comparison in the editor with no external dependency.

<sub>Package Control submission prepared with the help of [Claude Code](https://claude.com/claude-code); I'll be handling this review myself.</sub>