### PR TITLE
Add Harbour

### DIFF
--- a/repository/h.json
+++ b/repository/h.json
@@ -257,6 +257,17 @@
 			]
 		},
 		{
+			"name": "Harbour",
+			"details": "https://github.com/mirogeorg/Harbour",
+			"labels": ["language syntax", "completions", "snippets"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Hare",
 			"details": "https://github.com/artursartamonovs/hare-highlight",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package: test files.

My package is Harbour syntax highlighting and editing support for Harbour source files in Sublime Text 4. It includes syntax highlighting, completions, snippets, and searchable function help through the command palette.

There are no packages like it in Package Control.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore