### PR TITLE
Add LocalKeepAI

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1509,6 +1509,17 @@
 			]
 		},
 		{
+			"name": "LocalKeepAI",
+			"details": "https://github.com/laynef/localkeep-sublime",
+			"labels": ["ai", "assistant", "code generation"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Localpod",
 			"details": "https://github.com/ijoyc/Localpod",
 			"labels": ["cocoapods", "development pods", "ios"],


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. *** (n/a — not a syntax)
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is **Local Keep AI** — a local-first AI coding assistant for Sublime Text. It drives the `lk` command line tool (`pip install local-keep-ai-cli`) to explain, refactor and generate tests for the current selection or file, generate a commit message from the staged diff, run an agentic task, and switch between models. It works against local models (Ollama, llama.cpp GGUF) with no API key, as well as hosted and OpenRouter models. Output streams into an output panel. The CLI is resolved from the user's environment at runtime and never bundled.

There are no packages like it in Package Control. The closest existing entries are single-provider assistants tied to a hosted API and an API key; this one is built around locally-run models with the cloud as an option rather than a requirement.

Notes on the entry:

- `"sublime_text": ">=4107"` — the plugin targets the Python 3.8 plugin host (it ships a `.python-version` of `3.8`), so it is correctly excluded from builds that only offer the 3.3 host rather than failing to load on them.
- Key bindings: the package ships **no** active bindings. The platform keymap files contain commented-out suggestions only, and `Preferences → Package Settings → Local Keep AI → Key Bindings` opens the user's own keymap in split view for anyone who wants them.
- Menu entries are under `Tools → Local Keep AI`; there are no context menu entries.
- `.gitattributes` export-ignores the repo icon and dotfiles so they are not part of an install.

Happy to make any changes you'd like — I maintain this alongside the project's other editor integrations and will keep it updated.