### PR TITLE
Add GlyphConstruction

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1103,6 +1103,17 @@
 			]
 		},
 		{
+		    "name": "GlyphConstruction",
+		    "details": "https://github.com/adbac/GlyphConstruction-SublimePackage",
+		    "labels": ["language syntax", "completions"],
+		    "releases": [
+		        {
+		            "sublime_text": ">=3000",
+		            "tags": true
+		        }
+		    ]
+		}
+		{
 			"name": "GM Syntax",
 			"details": "https://github.com/andyp123/GMSyntax",
 			"labels": ["language syntax"],

--- a/repository/g.json
+++ b/repository/g.json
@@ -1103,15 +1103,15 @@
 			]
 		},
 		{
-		    "name": "GlyphConstruction",
-		    "details": "https://github.com/adbac/GlyphConstruction-SublimePackage",
-		    "labels": ["language syntax", "completions"],
-		    "releases": [
-		        {
-		            "sublime_text": ">=3092",
-		            "tags": true
-		        }
-		    ]
+			"name": "GlyphConstruction",
+			"details": "https://github.com/adbac/GlyphConstruction-SublimePackage",
+			"labels": ["language syntax", "completions"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
 		},
 		{
 			"name": "GM Syntax",

--- a/repository/g.json
+++ b/repository/g.json
@@ -1108,7 +1108,7 @@
 		    "labels": ["language syntax", "completions"],
 		    "releases": [
 		        {
-		            "sublime_text": ">=3000",
+		            "sublime_text": ">=3092",
 		            "tags": true
 		        }
 		    ]

--- a/repository/g.json
+++ b/repository/g.json
@@ -1112,7 +1112,7 @@
 		            "tags": true
 		        }
 		    ]
-		}
+		},
 		{
 			"name": "GM Syntax",
 			"details": "https://github.com/andyp123/GMSyntax",


### PR DESCRIPTION
- [X] I'm the package's author and/or maintainer.
- [X] I have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [X] My package doesn't add context menu entries. *
- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [X] If my package is a syntax it doesn't also add a color scheme. ***
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package provides support for the [GlyphConstruction language](https://github.com/typemytype/GlyphConstruction), used in type design to describe how glyph shapes are built. It provides syntax highlighting, completions, comments support and smart typing pairs.

There are no packages like it in Package Control.