### PR TITLE
Add Publora

### DIFF
--- a/repository/p.json
+++ b/repository/p.json
@@ -2898,6 +2898,17 @@
 			]
 		},
 		{
+			"name": "Publora",
+			"details": "https://github.com/publora/sublime-publora",
+			"labels": ["utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Pue Syntax Highlight",
 			"details": "https://github.com/QingWei-Li/pue-syntax-highlight",
 			"labels": ["language syntax"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs](https://docs.sublimetext.io/guide/package-control/submitting.html).
- [x] I have tagged a release with a [semver](https://semver.org) version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes](https://www.git-scm.com/docs/gitattributes#_export_ignore) to exclude files from the package.

My package sends the text you have selected, or the whole file, to Publora, which publishes and schedules social media posts across ten networks. You pick the channel from the accounts you have connected, then choose between saving a draft and scheduling for a time.

The workflow it is built for: release notes, a changelog entry or a short write-up already exist in the editor, and the announcement should go out without a detour through a browser and a paste buffer.

There are no packages like it in Package Control. I looked for anything that posts to social networks and found nothing; the closest neighbours are packages that send text to a service for other purposes.

Some details a reviewer may want:

- Repository: https://github.com/publora/sublime-publora (MIT), tagged `1.0.1`
- Two commands, both in the command palette: **Publora: Send selection** and **Publora: Send this file**. No context menu entries, no key bindings.
- Settings are a single `api_key`, reachable through Preferences, Package Settings, Publora.
- One network destination, `https://api.publora.com`. Nothing else is contacted, no files outside the current view are read, nothing is stored.
- Requests run on a background thread, so the editor is never blocked while a post is created.
- Testing it needs a Publora account. The free plan is 15 posts a month and three connected accounts and does not ask for a card, so the package can be exercised end to end without paying.

Disclosure: I work on Publora, so I am both the author and the person who will keep this maintained.