### PR TITLE
Fix historical package names

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -688,7 +688,7 @@
 		},
 		{
 			"name": "GitHub Desktop",
-			"previous_names": ["Git​Hub.app Menu"],
+			"previous_names": ["GitHub.app Menu"],
 			"details": "https://github.com/braver/SublimeGitHub",
 			"releases": [
 				{

--- a/repository/j.json
+++ b/repository/j.json
@@ -169,7 +169,7 @@
 			"name": "Jasmine JS",
 			"details": "https://github.com/NicoSantangelo/sublime-jasmine",
 			"labels": ["language syntax", "snippets"],
-			"previous_names": ["jasmine", "jasmine bdd"],
+			"previous_names": ["Jasmine", "Jasmine BDD"],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
Remove a zero-width space copied into GitHub Desktop's previous name, and restore the original capitalization of Jasmine JS's previous names.

These values now match the package names historically used by Package Control and its lifecycle tombstones.

Note: Github doesn't show the WS change in `GitHub.app` but it was `Git<ZWS>Hub.app` before; likely the name was copy pasted from packagecontrol.io

But Sublime does:

<img width="737" height="430" alt="image" src="https://github.com/user-attachments/assets/f9f8ae4e-9ad8-44cd-93d8-bea27ae5b41e" />
