### PR TITLE
Add FileConverter

### DIFF
--- a/repository/f.json
+++ b/repository/f.json
@@ -624,6 +624,17 @@
 			]
 		},
 		{
+			"name": "FileConverter",
+			"details": "https://github.com/gerph/sublimetext-fileconverter",
+			"labels": ["utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "FileDialog",
 			"details": "https://github.com/shagabutdinov/sublime-file-dialog",
 			"labels": ["sublime-enhanced", "file navigation", "utilities"],

--- a/repository/f.json
+++ b/repository/f.json
@@ -626,7 +626,7 @@
 		{
 			"name": "FileConverter",
 			"details": "https://github.com/gerph/sublimetext-fileconverter",
-			"labels": ["utilities"],
+			"labels": ["utilities", "binary"],
 			"releases": [
 				{
 					"platforms": ["osx", "linux"],

--- a/repository/f.json
+++ b/repository/f.json
@@ -629,6 +629,7 @@
 			"labels": ["utilities"],
 			"releases": [
 				{
+					"platforms": ["osx", "linux"],
 					"sublime_text": ">=3092",
 					"tags": true
 				}


### PR DESCRIPTION
A generic external-tool binary file decode/encode engine for Sublime Text. Opens files matching a configured pattern by streaming them through an external command into a new view, and can encode edited text back through a reverse command for reversible formats. Ships handlers for several RISC OS binary filetypes plus generic examples (hex dump via xxd, disassembly via objdump, media metadata via exiftool).

<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [X] I'm the package's author and/or maintainer.
- [X] I have read [the docs][1].
- [X] I have tagged a release with a [semver][2] version number.
- [X] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *

*We do have context menu entries* Because the window that we show isn't a real file (and we don't want to allow the user to save back) it doesn't have 'Find in sidebar', 'Open Finder window' entries (they're greyed). So we add context options - only when you're in our windows - which allow you to do those operations. We also add an explicit item to Re-encode the file to save it back, through a tool. Since Cmd-s (ctrl-s) will only offer to save the text content and you don't usually want to blindly re-write binary files. I believe this is a suitable and valid use, but if you've got better ideas about how to handle it, that'd be cool :-)

- [X] My package doesn't add key bindings. **
- [X] Any commands are available via the command palette.
- [X] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [ ] If my package is a syntax it doesn't also add a color scheme. ***
- [X] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a generic binary presentation tool.
It can take a binary file, matched by filename, pass it through a configurable tool and show the user the output.
It can also (optionally) allow that file to be processed back to save a new file.

There are no packages like it in Package Control.
The closest are the PList loading tools, but I needed more control over how the files were handled, and to allow them to be saved back. And might as well make it generic so that other filetypes can be handled by people - object files being objdump'd, for example.


<!-- 
A word about AI use:
Although we use automation, a human will be reviewing your submission. An important part of this is an assessment of the ability and willingness of the human submitting the package (i.e. you) to support it long term. This is therefore primarily a human to human conversation. While you're welcome to use any form of automation, you are expected to participate in this conversation yourself.

*)   If you do need a context menu, make sure the menu applies to the cursor
     context, and the commands are conditional. Space in this menu is limited!
**)  There aren't enough keys for all packages, so you risk overriding those
     of other packages. You can put commented out suggestions in a keymap file, 
     and/or explain how to create bindings in your README.
***) Syntaxes should work in any color scheme the user chooses.

For bonus points also consider how the review guidelines apply to your package:
https://docs.sublimetext.io/reference/package-control/reviewing.html
-->
