### PR TITLE
Add Limitcode

### DIFF
--- a/repository/l.json
+++ b/repository/l.json
@@ -1083,6 +1083,17 @@
 			]
 		},
 		{
+			"name": "Limitcode",
+			"details": "https://github.com/Jawuilp/Limitcode",
+			"labels": ["ai", "coding assistant"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "LimitTabs",
 			"details": "https://github.com/maximilize/LimitTabs",
 			"releases": [

--- a/repository/l.json
+++ b/repository/l.json
@@ -1085,7 +1085,7 @@
 		{
 			"name": "Limitcode",
 			"details": "https://github.com/Jawuilp/Limitcode",
-			"labels": ["ai", "llm", "coding assistant"],
+			"labels": ["ai", "llm", "agent", "coding assistant"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/l.json
+++ b/repository/l.json
@@ -1085,7 +1085,7 @@
 		{
 			"name": "Limitcode",
 			"details": "https://github.com/Jawuilp/Limitcode",
-			"labels": ["ai", "coding assistant"],
+			"labels": ["ai", "llm", "coding assistant"],
 			"releases": [
 				{
 					"sublime_text": "*",

--- a/repository/l.json
+++ b/repository/l.json
@@ -1085,10 +1085,10 @@
 		{
 			"name": "Limitcode",
 			"details": "https://github.com/Jawuilp/Limitcode",
-			"labels": ["ai", "llm", "agent", "coding assistant"],
+			"labels": ["ai", "llm", "agent", "assistant", "chat"],
 			"releases": [
 				{
-					"sublime_text": "*",
+					"sublime_text": ">=4050",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

My package is an AI pair programming agent for Sublime Text. The agent only sees and touches the files you have open in the editor — no hidden filesystem scans, no shell access, no autopilot — with a side-by-side streaming chat, permission prompts before edits, and project-scoped conversation history.

There are no packages like it in Package Control.

** Regarding key bindings: the only bindings shipped (Enter, Shift+Enter, Escape, Up/Down) are scoped with a `setting.limitcode_chat_view` context, so they only act inside the package's own chat view and never override global keys. They are also listed in Preferences → Package Settings → Limitcode → Key Bindings.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore
