### PR TITLE
Add MarkdownX

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -786,6 +786,17 @@
 			]
 		},
 		{
+			"name": "MarkdownX",
+			"details": "https://github.com/mgomes/sublime-markdownx",
+			"labels": ["markdown", "preview"],
+			"releases": [
+				{
+					"sublime_text": ">=4092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Marked App Menu",
 			"details": "https://github.com/icio/sublime-text-marked",
 			"labels": ["markdown", "preview", "build system", "marked.app"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

On the context menu box: MarkdownX adds three entries (Preview in Sublime, Preview in Browser, Export to HTML). Each is conditional on the Markdown selector and hidden in every other context, per the note under `*`. Happy to drop them if you would rather.

My package is a live Markdown preview. It renders as you type into a pane beside the file, using minihtml and the editor's own color scheme, or into a browser tab served from localhost, which adds Mermaid diagrams, KaTeX math, wide tables, and a table of contents. Scrolling stays in sync both ways. Parsing is Mistune, vendored under BSD-3-Clause; highlight.js, Mermaid, and KaTeX are bundled as well, so nothing is fetched at runtime and no document leaves the machine. An Export to HTML command writes the document as a single self-contained file.

My package is similar to MarkdownPreview and MarkdownLivePreview. MarkdownPreview builds HTML and hands it to a browser; MarkdownLivePreview shows an in-editor pane. MarkdownX offers both targets over one document and one server, with the pane taking its colors from your color scheme and the browser adding diagrams, math, and a table of contents that the pane cannot render.
