### PR TITLE
Add Auto Maximize

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2303,6 +2303,19 @@
 			]
 		},
 		{
+			"name": "Auto Maximize",
+			"details": "https://github.com/mrflamingchad67/sublime-auto-maximize",
+			"author": "mrflamingchad67",
+			"labels": ["utilities", "window"],
+			"releases": [
+				{
+					"sublime_text": ">=4050",
+					"platforms": ["windows"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Auto Refresh",
 			"details": "https://github.com/Wouterdek/AutoRefresh",
 			"releases": [


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission.
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.
  - N/A — the repository contains only the plugin file, README.md and LICENSE.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is **Auto Maximize**, a small Windows-only plugin that makes Sublime Text start with its window(s) maximized instead of restored to their previous size, and maximizes any window opened later. It uses the native `ShowWindow` call on `Window.hwnd()` (hence the `>=4050` requirement and windows-only platform), so it does not interfere with fullscreen mode at all.

There are no packages like it in Package Control. The closest existing ones (e.g. AutomaticFullscreen) toggle real fullscreen mode; this plugin deliberately maximizes the OS window instead, keeping title bar, tabs and taskbar visible.
