### PR TITLE
Add st4-py38- tag prefix for Requester and TreeSitter plugins, for ST builds 4107 - 4200

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -1388,7 +1388,11 @@
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4107",
+					"sublime_text": "4107 - 4200",
+					"tags": "st4-py38-"
+				},
+				{
+					"sublime_text": ">=4205",
 					"tags": true
 				}
 			]

--- a/repository/t.json
+++ b/repository/t.json
@@ -3474,7 +3474,11 @@
 			"author": "kylebebak",
 			"releases": [
 				{
-					"sublime_text": ">=4107",
+					"sublime_text": "4107 - 4200",
+					"tags": "st4-py38-"
+				},
+				{
+					"sublime_text": ">=4205",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
- Add st4-py38- tag prefix for Requester and TreeSitter plugins, for ST builds 4107 - 4200
- Past build 4200, there is no longer a python 3.8 plugin host, which broke both of these plugins
- Requester has already been updated for the Python 3.14 plugin host, and TreeSitter is almost ready
  - https://github.com/kylebebak/Requester/releases/tag/st4-py38-2.39.6

The following checklist may not be super relevant, because these aren't new packages. They're existing packages that are being updated for build 4205, which replaced the python 3.8 plugin host with 3.14.

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

---

Also, it's worth noting that these errors are all pre-existing "issues" in pretty much every version of Requester that's been shipped

```
[84](https://github.com/sublimehq/package_control_channel/actions/runs/32907533352/job/97994757021?pr=9533#step:2:303)
  Error: Do not import root-level plugin module '.add_path'. Sublime Text loads root-level Python files as independent plugins; move shared code into a subpackage.
      File: core/__init__.py
      Line: 13, Column: 1
  Error: The binding ['ctrl+r'] has no context. Packages should only ship key bindings that use a specific context such as 'selector', 'setting.*', or a custom context key. If the binding defines a main entry-point to your package, move it to an example keymap instead so users can decide on their own.
      File: Default (OSX).sublime-keymap
  Error: The binding ['ctrl+alt+r'] has no context. Packages should only ship key bindings that use a specific context such as 'selector', 'setting.*', or a custom context key. If the binding defines a main entry-point to your package, move it to an example keymap instead so users can decide on their own.
      File: Default.sublime-keymap
```
