### PR TITLE
Add raylang

### DIFF
--- a/repository/r.json
+++ b/repository/r.json
@@ -431,6 +431,18 @@
 			]
 		},
 		{
+			"name": "raylang",
+			"details": "https://github.com/ray-language/sublime-raylang",
+			"description": "Syntax highlighting for the raylang programming language (.ray), plus its compiled templates (.ray.html) and LSP setup.",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Razor C# Syntax",
 			"details": "https://github.com/LoneBoco/razor-sublime",
 			"description": "Razor C# .cshtml language syntax for Sublime Text 4.",


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [ ] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is **raylang** — syntax highlighting for the [raylang programming language](https://github.com/ray-language/raylang) (`.ray` files), plus its compiled template dialect (`.ray.html`), and instructions to wire the language server via the LSP package.

There are no packages like it in Package Control.

Details:

- Repo: https://github.com/ray-language/sublime-raylang (semver tag `1.0.0`)
- Ships `.sublime-syntax` grammars; the template syntax uses `version: 2`, hence `>=4107`.
- License: MIT OR Apache-2.0.
- Name is not taken on packagecontrol.io; scopes follow the language's TextMate grammar (same scopes as its VS Code extension).
- No commands, context menus, key bindings, or color scheme are added — it's a syntax-only package plus a syntax-specific `.sublime-settings`.
- On `.gitattributes` (last box left unchecked): the published mirror contains only the shipped package files — the two `.sublime-syntax` files, `Comments.tmPreferences`, one `.sublime-settings`, the README and licenses. There are no images, test files, or `.sublime-project`/`.sublime-workspace` to `export-ignore`, so none is included.
