### PR TITLE
ClaudeSublime: add description, readme and labels

### DIFF
--- a/repository/c.json
+++ b/repository/c.json
@@ -1411,9 +1411,7 @@
 		{
 			"name": "ClaudeSublime",
 			"details": "https://gitlab.com/petr.jakub/claudesublime",
-			"description": "Run Claude Code in a Sublime Text panel with live highlighting of the files it edits, plus optional rsync-over-SSH project sync.",
-			"readme": "https://gitlab.com/petr.jakub/claudesublime/-/raw/main/README.md",
-			"labels": ["claude", "claude-code", "anthropic", "ai", "terminal", "terminus", "rsync", "sync"],
+			"labels": ["claude", "claude-code", "anthropic", "ai", "rsync", "sync"],
 			"releases": [
 				{
 					"sublime_text": ">=4107",

--- a/repository/c.json
+++ b/repository/c.json
@@ -1411,6 +1411,9 @@
 		{
 			"name": "ClaudeSublime",
 			"details": "https://gitlab.com/petr.jakub/claudesublime",
+			"description": "Run Claude Code in a Sublime Text panel with live highlighting of the files it edits, plus optional rsync-over-SSH project sync.",
+			"readme": "https://gitlab.com/petr.jakub/claudesublime/-/raw/main/README.md",
+			"labels": ["claude", "claude-code", "anthropic", "ai", "terminal", "terminus", "rsync", "sync"],
 			"releases": [
 				{
 					"sublime_text": ">=4107",


### PR DESCRIPTION
Follow-up to #9494 (ClaudeSublime, already merged).

The packagecontrol.io page shows "No description provided" and "No readme provided". Since the package is hosted on **GitLab**, the readme isn't auto-detected the way it is for GitHub repos, so I'm adding it explicitly:

- `description` — short blurb for the package page.
- `readme` — raw URL to the repo's README on the default branch (`main`); returns HTTP 200.
- `labels` — search keywords (claude, claude-code, anthropic, ai, terminal, terminus, rsync, sync).

No release/tag changes.
