### PR TITLE
Add MarkdownGlance

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -707,7 +707,6 @@
 			]
 		},
 		{
-			"name": "MarkdownGlance",
 			"details": "https://github.com/pandadolphin/MarkdownGlance",
 			"labels": ["markdown", "preview"],
 			"releases": [

--- a/repository/m.json
+++ b/repository/m.json
@@ -707,6 +707,18 @@
 			]
 		},
 		{
+			"name": "MarkdownGlance",
+			"details": "https://github.com/pandadolphin/MarkdownGlance",
+			"labels": ["markdown", "preview"],
+			"releases": [
+				{
+					"sublime_text": ">=4200",
+					"platforms": ["*"],
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/sekogan/MarkdownLight",
 			"labels": ["language syntax", "markdown"],
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [ ] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is a live Markdown preview that renders into an editor group of the same window, using the Sublime API alone — no browser, no WebView, no external process, and no dependency outside the standard library and a vendored parser.

About the key bindings box: the package ships a keymap, so the box stays unchecked. What it takes, and why:

- `ctrl+k, v` — Open Preview to the Side. Bound by nothing in Sublime Text; guarded by a Markdown-source context.
- `ctrl+shift+v` — Toggle Preview. This one shadows `paste_and_indent`, and only while a Markdown source view or a preview this package created is focused. It is the key VS Code and Zed both give the Markdown preview, next to the `ctrl+k, v` that comes from the same keymap, so it is the key a user arriving from either editor presses first. Paste and Indent earns its binding where indentation carries meaning — Python, C++ — rather than in Markdown prose, and Edit → Paste and Indent still runs it there by name.
- `ctrl+shift+b` — Toggle Outline, added in 0.2.0. This shadows `build` with `select: true`, the Build With… picker, and only while a Markdown source view or an outline this package created is focused. Markdown has no build system, so the picker is not something a user was reaching for in that buffer, and plain `ctrl+b` — Build — is untouched everywhere. It is the key Zed gives its outline panel, and the feature is Zed's outline panel: a list of the headings as they are written in the buffer, beside the file, with no preview open. [ADR 0010](https://github.com/pandadolphin/MarkdownGlance/blob/main/docs/adr/0010-source-outline-and-ctrl-shift-b.md) has the measurements and the reasoning.
- `ctrl+=` / `ctrl+-` / `ctrl+0` and ctrl+scroll — zoom, only while a preview or outline this package created is focused: a scratch view with no font to size and no sidebar to focus.

0.1.2 moved the toggle onto the `ctrl+k, shift+v` chord to leave Paste and Indent alone, and I said so earlier in this PR. That was wrong twice over and 0.1.3 reverted it: the chord does not dispatch at all — Sublime Text lists it in the palette and binds no chord whose second key is bare or shift-only — and the parity argument above is the stronger one. The reasoning and the measurements are in [ADR 0008](https://github.com/pandadolphin/MarkdownGlance/blob/main/docs/adr/0008-default-key-bindings.md) and [ADR 0009](https://github.com/pandadolphin/MarkdownGlance/blob/main/docs/adr/0009-full-screen-toggle-returns-to-ctrl-shift-v.md), and the README says plainly which default changes and how to get it back.

Two single-stroke keys outside the package's own views is two more than none, so the repository names them in one place — `SINGLE_STROKE_OUTSIDE_PREVIEW` in `tests/unit/test_package_identity.py` — and the test suite fails if a third appears without a decision record beside it.

Every command is in the command palette without any binding, and the defaults open from Preferences → Package Settings → MarkdownGlance → Key Bindings. If you would still rather the keymap ship commented out, say so and I will.

My package is similar to MarkdownLivePreview. However it should still be added because it is an independent Sublime Text 4 implementation rather than a fork: it previews unsaved buffers, follows the active color scheme, adds a navigable table of contents and an outline of the raw source, per-session zoom, bounded asynchronous remote images and opt-in Mermaid, and it typesets GFM tables to the measured width of the preview since minihtml cannot lay out a table. Coexistence and the shortcut overlap are documented in `docs/migration.md`.

