### PR TITLE
Add VisuBezier

### DIFF
--- a/repository/v.json
+++ b/repository/v.json
@@ -667,6 +667,17 @@
 			]
 		},
 		{
+			"name": "VisuBezier",
+			"details": "https://github.com/mrcgrtz/visubezier",
+			"labels": ["css", "preview", "hover", "utilities"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Vlt",
 			"details": "https://github.com/tomalec/Sublime-Text-2-Vlt-Plugin",
 			"releases": [


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package previews CSS easing functions on hover. It is a fork of [VisuBezier](https://github.com/chriskirknielsen/visubezier) on VS Code.

There are no packages like it in Package Control.