### PR TITLE
Add MarkdownPreviewOverlay

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -764,6 +764,17 @@
 			]
 		},
 		{
+			"name": "MarkdownPreviewOverlay",
+			"details": "https://github.com/flashmodel/MarkdownPreviewOverlay",
+			"labels": ["markdown", "preview", "reader"],
+			"releases": [
+				{
+					"sublime_text": ">=4050",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/naokazuterada/MarkdownTOC",
 			"labels": ["markdown", "toc", "table of contents"],
 			"releases": [


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is an editor-native Markdown reading mode for Sublime Text that folds the source buffer and renders the document as a themed miniHTML overlay phantom inside the same view.

The package is built on the concept discussed in the Sublime Text forum topic: [provide-markdown-preview-mode](https://forum.sublimetext.com/t/provide-markdown-preview-mode-using-folded-source-and-phantom/79042)

My package is similar to MarkdownPreview and MarkdownLivePreview. But unlike external browser preview or split-pane tools, it renders formatted Markdown directly inside the active editor view without splitting windows or launching external browsers, while preserving cursor positions, scroll offsets, and selections.
