### PR TITLE
Add cph-by-chenkx to channel

### DIFF
--- a/cph/cph-by-chenkx/1.0.6.json
+++ b/cph/cph-by-chenkx/1.0.6.json
@@ -1,0 +1,4 @@
+{
+  "sublime_text": "*",
+  "tags": true
+}

--- a/repository/c.json
+++ b/repository/c.json
@@ -1,10 +1,17 @@
-{
+﻿{
 	"schema_version": "3.0.0",
 	"packages": [
 		{
 			"name": "C Family Rewrite (C23 and C++23)",
 			"details": "https://github.com/camila314/C-Family-Rewrite",
-			"labels": ["language syntax", "c", "c++", "objc", "objc++", "objective-c"],
+			"labels": [
+				"language syntax",
+				"c",
+				"c++",
+				"objc",
+				"objc++",
+				"objective-c"
+			],
 			"description": "Complete modern rewrite of C/C++/ObjC/ObjC++ syntax",
 			"releases": [
 				{
@@ -16,7 +23,10 @@
 		{
 			"name": "C Improved",
 			"details": "https://github.com/abusalimov/SublimeCImproved",
-			"labels": ["language syntax", "c"],
+			"labels": [
+				"language syntax",
+				"c"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -27,7 +37,10 @@
 		{
 			"name": "C# Compile & Run",
 			"details": "https://github.com/chrokh/csharp-build-singlefile-sublime-text-2",
-			"labels": ["build system", "c#"],
+			"labels": [
+				"build system",
+				"c#"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -38,7 +51,10 @@
 		{
 			"name": "C# Snippets",
 			"details": "https://github.com/etic/CSharpSnippets",
-			"labels": ["snippets", "c#"],
+			"labels": [
+				"snippets",
+				"c#"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -49,7 +65,11 @@
 		{
 			"name": "C++ & C Single File Builder - Minghang Yang",
 			"details": "https://github.com/inouetoukyou/C_CppSingleFileBuilder_MinghangYang",
-			"labels": ["build system", "c", "c++"],
+			"labels": [
+				"build system",
+				"c",
+				"c++"
+			],
 			"author": "Minghang Yang",
 			"description": "Build and Run in Terminal for Single File C & C++",
 			"releases": [
@@ -63,7 +83,12 @@
 			"name": "C++ Classhelper",
 			"details": "https://github.com/pr0grammr/cppclasshelper-sublime-text-plugin",
 			"author": "Fabian Schilf",
-			"labels": ["c++", "automation", "utilities", "file creation"],
+			"labels": [
+				"c++",
+				"automation",
+				"utilities",
+				"file creation"
+			],
 			"description": "Create C++ class with Headerfile",
 			"releases": [
 				{
@@ -75,7 +100,12 @@
 		{
 			"name": "C++ Completions",
 			"details": "https://github.com/tushortz/CPP-Completions",
-			"labels": ["auto-complete", "completions", "snippets", "c++"],
+			"labels": [
+				"auto-complete",
+				"completions",
+				"snippets",
+				"c++"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -86,7 +116,10 @@
 		{
 			"name": "C++ Snippets",
 			"details": "https://github.com/Rapptz/cpp-sublime-snippet",
-			"labels": ["snippets", "c++"],
+			"labels": [
+				"snippets",
+				"c++"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -97,7 +130,10 @@
 		{
 			"name": "C++ Starting Kit",
 			"details": "https://github.com/kodLite/cppStartingKit",
-			"labels": ["language syntax", "c++"],
+			"labels": [
+				"language syntax",
+				"c++"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -108,7 +144,10 @@
 		{
 			"name": "C++11",
 			"details": "https://github.com/noct/sublime-cpp11",
-			"labels": ["language syntax", "c++"],
+			"labels": [
+				"language syntax",
+				"c++"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -119,7 +158,13 @@
 		{
 			"name": "C++NamespaceTool",
 			"details": "https://github.com/myurtoglu/NamespaceTool",
-			"labels": ["formatting", "language syntax", "refactoring", "text manipulation", "c++"],
+			"labels": [
+				"formatting",
+				"language syntax",
+				"refactoring",
+				"text manipulation",
+				"c++"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -130,7 +175,11 @@
 		{
 			"name": "C++YouCompleteMe",
 			"details": "https://github.com/glymehrvrd/CppYCM",
-			"labels": ["auto-complete", "linting", "c++"],
+			"labels": [
+				"auto-complete",
+				"linting",
+				"c++"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -141,7 +190,9 @@
 		{
 			"name": "C0",
 			"details": "https://github.com/mahmoudalismail/SublimeC0",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -152,7 +203,10 @@
 		{
 			"name": "C11",
 			"details": "https://github.com/petervaro/C11",
-			"labels": ["language syntax", "c"],
+			"labels": [
+				"language syntax",
+				"c"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -163,7 +217,10 @@
 		{
 			"name": "C99",
 			"details": "https://github.com/noct/sublime-c99",
-			"labels": ["language syntax", "c"],
+			"labels": [
+				"language syntax",
+				"c"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -174,7 +231,11 @@
 		{
 			"name": "Cacher",
 			"details": "https://github.com/CacherApp/cacher-sublime",
-			"labels": ["snippets", "gist", "code library"],
+			"labels": [
+				"snippets",
+				"gist",
+				"code library"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -185,7 +246,9 @@
 		{
 			"name": "Caddyfile Syntax",
 			"details": "https://github.com/caddyserver/sublimetext",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -196,7 +259,9 @@
 		{
 			"name": "Caffe Prototxt Syntax",
 			"details": "https://github.com/zironycho/sublime-caffe-prototxt-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -207,7 +272,9 @@
 		{
 			"name": "CakePHP (Native)",
 			"details": "https://github.com/josegonzalez/sublimetext-cakephp",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -218,7 +285,9 @@
 		{
 			"name": "CakePHP (tmbundle)",
 			"details": "https://github.com/cakephp/cakephp-tmbundle",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -248,7 +317,10 @@
 		},
 		{
 			"name": "Calendar Popup",
-			"labels": ["calendar", "utilities"],
+			"labels": [
+				"calendar",
+				"utilities"
+			],
 			"details": "https://github.com/blalor/SublimeCalendarPopup",
 			"releases": [
 				{
@@ -260,7 +332,9 @@
 		{
 			"name": "Can I Use",
 			"details": "https://github.com/Azd325/sublime-text-caniuse",
-			"labels": ["caniuse"],
+			"labels": [
+				"caniuse"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -271,7 +345,9 @@
 		{
 			"name": "Candela Color Schemes",
 			"details": "https://github.com/schovi/candela-themes-sublime",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3149",
@@ -282,7 +358,9 @@
 		{
 			"name": "Candy Dark Color Scheme",
 			"details": "https://github.com/rahulsharmagg/Candy-Dark",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -293,7 +371,10 @@
 		{
 			"name": "caniuse_local",
 			"details": "https://github.com/leecade/caniuse_local",
-			"labels": ["caniuse", "offline"],
+			"labels": [
+				"caniuse",
+				"offline"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -315,7 +396,13 @@
 			"name": "Canvas Snippets",
 			"details": "https://github.com/skadimoolam/Canvas-Snippets",
 			"author": "Adi",
-			"labels": ["auto-complete", "snippets", "canvas", "html5", "javascript"],
+			"labels": [
+				"auto-complete",
+				"snippets",
+				"canvas",
+				"html5",
+				"javascript"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -327,7 +414,9 @@
 			"name": "CAOS Syntax Highlighter",
 			"details": "https://github.com/KeyboardInterrupt/sublime-caos-syntax",
 			"author": "KeyboardInterrupt",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -338,7 +427,9 @@
 		{
 			"name": "Cap'n Proto Syntax",
 			"details": "https://github.com/joshuawarner32/capnproto-sublime",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -349,7 +440,9 @@
 		{
 			"name": "Capo",
 			"details": "https://github.com/kirillbuga/capo",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -360,7 +453,9 @@
 		{
 			"name": "CapRails",
 			"details": "https://github.com/schneidmaster/cap_rails",
-			"labels": ["capistrano"],
+			"labels": [
+				"capistrano"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -371,7 +466,9 @@
 		{
 			"name": "Capybara Snippets",
 			"details": "https://github.com/asux/sublime-capybara-snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -382,7 +479,12 @@
 		{
 			"name": "Carbon",
 			"details": "https://github.com/molnarmark/carbonsublime",
-			"labels": ["carbon", "carbon enhanced", "carbon now", "carbon now sh"],
+			"labels": [
+				"carbon",
+				"carbon enhanced",
+				"carbon now",
+				"carbon now sh"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -393,7 +495,9 @@
 		{
 			"name": "Carbon Programming Language",
 			"details": "https://github.com/RohanVashisht1234/sublime_text_carbon_syntax_highlighter",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -404,7 +508,15 @@
 		{
 			"name": "Carto",
 			"details": "https://github.com/yohanboniface/Carto-sublime",
-			"labels": ["language syntax", "auto-complete", "carto", "cartocss", "mapnik", "openstreetmap", "osm"],
+			"labels": [
+				"language syntax",
+				"auto-complete",
+				"carto",
+				"cartocss",
+				"mapnik",
+				"openstreetmap",
+				"osm"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -415,7 +527,12 @@
 		{
 			"name": "Carve",
 			"details": "https://github.com/markup-carve/sublime-carve",
-			"labels": ["language syntax", "carve", "markup", "djot"],
+			"labels": [
+				"language syntax",
+				"carve",
+				"markup",
+				"djot"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -456,7 +573,9 @@
 		{
 			"name": "Cataracted Dark Color Scheme",
 			"details": "https://github.com/betraying/cataracted-dark-sublime-text",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -467,7 +586,9 @@
 		{
 			"name": "Catkin Builder",
 			"details": "https://github.com/ZacharyTaylor/Catkin-Builder",
-			"labels": ["build system"],
+			"labels": [
+				"build system"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -478,8 +599,14 @@
 		{
 			"name": "Catppuccin color schemes",
 			"details": "https://github.com/catppuccin/sublime-text",
-			"author": ["Catppuccin"],
-			"labels": ["color scheme", "dark", "light"],
+			"author": [
+				"Catppuccin"
+			],
+			"labels": [
+				"color scheme",
+				"dark",
+				"light"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3100",
@@ -490,7 +617,9 @@
 		{
 			"name": "Cattleya Color Scheme",
 			"details": "https://github.com/patrickfatrick/cattleya-theme-sublime",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -501,7 +630,10 @@
 		{
 			"name": "CBP Syntax Highlighter",
 			"details": "https://github.com/destruc7i0n/CBP_Sublime",
-			"labels": ["minecraft", "language syntax"],
+			"labels": [
+				"minecraft",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -512,11 +644,15 @@
 		{
 			"name": "CComplete",
 			"details": "https://github.com/ibensw/CComplete",
-			"labels": ["auto-complete"],
+			"labels": [
+				"auto-complete"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["linux"],
+					"platforms": [
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -534,7 +670,11 @@
 		{
 			"name": "CDNUpdates",
 			"details": "https://github.com/HorlogeSkynet/CDNUpdates",
-			"labels": ["cdn", "updates", "web development"],
+			"labels": [
+				"cdn",
+				"updates",
+				"web development"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -558,7 +698,10 @@
 		},
 		{
 			"details": "https://github.com/andylamb/Ceer",
-			"labels": ["code navigation", "file navigation"],
+			"labels": [
+				"code navigation",
+				"file navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -583,7 +726,10 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx", "linux"],
+					"platforms": [
+						"osx",
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -611,7 +757,15 @@
 		{
 			"name": "CFDocs",
 			"details": "https://github.com/mikesprague/sublime-cfdocs",
-			"labels": ["cfdocs", "cfml", "lucee", "railo", "coldfusion", "documentation", "search"],
+			"labels": [
+				"cfdocs",
+				"cfml",
+				"lucee",
+				"railo",
+				"coldfusion",
+				"documentation",
+				"search"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -622,7 +776,10 @@
 		{
 			"name": "CFEngine",
 			"details": "https://github.com/lastops/sublime-cfengine",
-			"labels": ["formatting", "language syntax"],
+			"labels": [
+				"formatting",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -633,7 +790,10 @@
 		{
 			"name": "cfengine_beautifier",
 			"details": "https://github.com/naksu/cfengine_beautifier",
-			"labels": ["formatting", "language syntax"],
+			"labels": [
+				"formatting",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -644,7 +804,9 @@
 		{
 			"name": "CFG Configuration Syntax Highlighting",
 			"details": "https://github.com/aronj/CFGGameConfigurationSyntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -655,7 +817,12 @@
 		{
 			"name": "CFML",
 			"details": "https://github.com/jcberquist/sublimetext-cfml",
-			"labels": ["language syntax", "cfml", "coldfusion", "lucee"],
+			"labels": [
+				"language syntax",
+				"cfml",
+				"coldfusion",
+				"lucee"
+			],
 			"releases": [
 				{
 					"sublime_text": "<4084",
@@ -680,7 +847,9 @@
 		{
 			"name": "CForm",
 			"details": "https://github.com/beaknit/cform",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -691,7 +860,9 @@
 		{
 			"name": "cFos ml syntax",
 			"details": "https://github.com/ArmorDarks/cfos-ml-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -702,7 +873,11 @@
 		{
 			"name": "Cfserver",
 			"details": "https://github.com/aam/cfserver-sublime-bundle",
-			"labels": ["auto-complete", "code navigation", "language syntax"],
+			"labels": [
+				"auto-complete",
+				"code navigation",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -743,7 +918,9 @@
 		{
 			"name": "ChaiScript",
 			"details": "https://github.com/ChaiScript/sublimetext-chaiscript",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -775,7 +952,9 @@
 		{
 			"name": "ChapelLang",
 			"details": "https://github.com/acrosby/sublimetext-chapel",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -796,7 +975,10 @@
 		{
 			"name": "Char Value",
 			"details": "https://github.com/alimony/sublime-char-value",
-			"labels": ["formatting", "text manipulation"],
+			"labels": [
+				"formatting",
+				"text manipulation"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -808,7 +990,9 @@
 			"name": "Charmci",
 			"details": "https://github.com/matthiasdiener/Charmci-Sublime-Syntax",
 			"description": "Syntax highlighting for Charm++ .ci files",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -841,7 +1025,12 @@
 			"author": "Victor Rachieru",
 			"description": "Quick reference for those pesky little details that just won't stay in your head.",
 			"details": "https://github.com/vrachieru/cheatsheet",
-			"labels": ["cheatsheet", "documentation", "snippets", "utilities"],
+			"labels": [
+				"cheatsheet",
+				"documentation",
+				"snippets",
+				"utilities"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -866,7 +1055,9 @@
 		{
 			"name": "CheerfullyDark",
 			"details": "https://github.com/jorgehatccrma/CheerfullyDark",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -877,7 +1068,9 @@
 		{
 			"name": "Cheetah Syntax Highlighting",
 			"details": "https://github.com/gs/Cheetah.tmbundle",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -938,7 +1131,12 @@
 		{
 			"name": "Chinese Words Cutter",
 			"details": "https://github.com/absop/ChineseTokenizer",
-			"labels": ["chinese", "中文", "分词", "选词"],
+			"labels": [
+				"chinese",
+				"中文",
+				"分词",
+				"选词"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -959,7 +1157,13 @@
 		{
 			"name": "ChineseLocalizations",
 			"details": "https://github.com/rexdf/ChineseLocalization",
-			"labels": ["localization", "chinese", "中文", "japanese", "日本語"],
+			"labels": [
+				"localization",
+				"chinese",
+				"中文",
+				"japanese",
+				"日本語"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -984,7 +1188,11 @@
 		{
 			"name": "ChineseOpenConvert",
 			"details": "https://github.com/rexdf/SublimeChineseConvert",
-			"labels": ["translation", "chinese", "中文"],
+			"labels": [
+				"translation",
+				"chinese",
+				"中文"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -995,7 +1203,11 @@
 		{
 			"name": "Chipper",
 			"details": "https://github.com/andymaster01/chipper_syntax_sublime_text",
-			"labels": ["chipper", "chip8", "language syntax"],
+			"labels": [
+				"chipper",
+				"chip8",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3084",
@@ -1006,7 +1218,11 @@
 		{
 			"name": "ChipseaAssembly",
 			"details": "https://github.com/junglefive/ChipseaAssembly",
-			"labels": ["chipsea", "csassembly", "language syntax"],
+			"labels": [
+				"chipsea",
+				"csassembly",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1020,7 +1236,10 @@
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["osx", "linux"],
+					"platforms": [
+						"osx",
+						"linux"
+					],
 					"branch": "master"
 				}
 			]
@@ -1028,7 +1247,9 @@
 		{
 			"name": "ChoiceScript",
 			"details": "https://github.com/fawkesy/choicescript-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1049,7 +1270,9 @@
 		{
 			"name": "ChordPro",
 			"details": "https://github.com/kudanai/sublime-chordpro",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1060,7 +1283,9 @@
 		{
 			"name": "Chouku Color Scheme",
 			"details": "https://github.com/droekm/chouku",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1083,7 +1308,10 @@
 			"name": "Chrome Color Scheme",
 			"description": "Syntax theme mimicking Chrome Developer Tools",
 			"details": "https://github.com/mapsiter/Chrome-Color-Scheme",
-			"labels": ["color scheme", "language syntax"],
+			"labels": [
+				"color scheme",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1114,17 +1342,29 @@
 		{
 			"name": "Chromeless",
 			"details": "https://github.com/ggets/Sublime_Chromeless",
-			"labels": ["window manipulation", "fullscreen", "layout", "titlebar", "title bar", "chrome"],
+			"labels": [
+				"window manipulation",
+				"fullscreen",
+				"layout",
+				"titlebar",
+				"title bar",
+				"chrome"
+			],
 			"author": "GGets",
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["windows", "linux"],
+					"platforms": [
+						"windows",
+						"linux"
+					],
 					"tags": "st3-"
 				},
 				{
 					"sublime_text": ">=4096",
-					"platforms": ["windows"],
+					"platforms": [
+						"windows"
+					],
 					"tags": true
 				}
 			]
@@ -1144,7 +1384,14 @@
 			"author": "Josh Karlin",
 			"description": "Shows Chromium code cross-references from cs.chromium.org",
 			"details": "https://github.com/karlinjf/ChromiumXRefs",
-			"labels": ["chrome", "chromium", "cross reference", "references", "code search", "call graph"],
+			"labels": [
+				"chrome",
+				"chromium",
+				"cross reference",
+				"references",
+				"code search",
+				"call graph"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3118",
@@ -1155,7 +1402,9 @@
 		{
 			"name": "Chuby Ninja Color Scheme",
 			"details": "https://github.com/jturcotte/SublimeChubyNinja",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1166,7 +1415,9 @@
 		{
 			"name": "ChucK Syntax",
 			"details": "https://github.com/nathanleiby/ChucK.tmbundle",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1177,7 +1428,9 @@
 		{
 			"name": "Ciapre Color Scheme",
 			"details": "https://github.com/vinhnx/Ciapre.tmTheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1198,7 +1451,9 @@
 		{
 			"name": "Circuits",
 			"details": "https://github.com/jdpatt/circuits",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1209,7 +1464,9 @@
 		{
 			"name": "Cirru",
 			"details": "https://github.com/cirru/sublime-cirru",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1220,8 +1477,12 @@
 		{
 			"name": "Cisco",
 			"details": "https://github.com/mburknoe/CiscoSyntax-Badwifi-Sublime-syntax",
-			"previous_names": ["Cisco Syntax Highlighter"],
-			"labels": ["language syntax"],
+			"previous_names": [
+				"Cisco Syntax Highlighter"
+			],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1232,7 +1493,9 @@
 		{
 			"name": "CiscoCollab",
 			"details": "https://github.com/tonynupe/CiscoCollab",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4000",
@@ -1253,7 +1516,9 @@
 		{
 			"name": "Citer",
 			"details": "https://github.com/mangecoeur/Citer",
-			"labels": ["citation academic markdown"],
+			"labels": [
+				"citation academic markdown"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1264,11 +1529,17 @@
 		{
 			"name": "CiteTeX",
 			"details": "https://github.com/alex1632/citetex",
-			"labels": ["latex", "tex", "cite"],
+			"labels": [
+				"latex",
+				"tex",
+				"cite"
+			],
 			"author": "Alexander K.",
 			"releases": [
 				{
-					"platforms": ["*"],
+					"platforms": [
+						"*"
+					],
 					"sublime_text": ">=3000",
 					"tags": true
 				}
@@ -1277,7 +1548,9 @@
 		{
 			"name": "Civic Color Scheme",
 			"details": "https://github.com/AntoineBoulanger/civic",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1288,7 +1561,10 @@
 		{
 			"name": "CJSX Syntax",
 			"details": "https://github.com/Guidebook/sublime-cjsx",
-			"labels": ["cjsx", "language syntax"],
+			"labels": [
+				"cjsx",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -1301,7 +1577,9 @@
 			"details": "https://github.com/ucl-casa-ce/claat-snippets-sublime",
 			"homepage": "https://www.connected-environments.org",
 			"author": "sjg",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1312,7 +1590,12 @@
 		{
 			"name": "Clafer Tools",
 			"details": "https://github.com/gsdlab/ClaferToolsST",
-			"labels": ["language syntax", "clafer", "compiler", "instance generator"],
+			"labels": [
+				"language syntax",
+				"clafer",
+				"compiler",
+				"instance generator"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1323,7 +1606,12 @@
 		{
 			"name": "Clang Format",
 			"details": "https://github.com/rosshemsley/SublimeClangFormat",
-			"labels": ["formatting", "clang", "c", "c++"],
+			"labels": [
+				"formatting",
+				"clang",
+				"c",
+				"c++"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1334,7 +1622,13 @@
 		{
 			"name": "Clang-Complete",
 			"details": "https://github.com/lvzixun/clang-complete",
-			"labels": ["completions", "clang", "c", "c++", "objective-c"],
+			"labels": [
+				"completions",
+				"clang",
+				"c",
+				"c++",
+				"objective-c"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1346,7 +1640,12 @@
 		{
 			"name": "ClangAutoComplete",
 			"details": "https://github.com/pl-ca/ClangAutoComplete",
-			"labels": ["completions", "clang", "c", "c++"],
+			"labels": [
+				"completions",
+				"clang",
+				"c",
+				"c++"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1357,7 +1656,10 @@
 		{
 			"name": "Clannad Theme",
 			"details": "https://github.com/lemorage/sublime-clannad-theme",
-			"labels": ["theme", "color scheme"],
+			"labels": [
+				"theme",
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1368,7 +1670,9 @@
 		{
 			"name": "Clarion",
 			"details": "https://github.com/fushnisoft/SublimeClarion",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1379,7 +1683,9 @@
 		{
 			"name": "Class Navigator",
 			"details": "https://github.com/malexer/SublimeClassNavigator",
-			"labels": ["code navigation"],
+			"labels": [
+				"code navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1400,7 +1706,11 @@
 		{
 			"name": "Claude Code IDE",
 			"details": "https://github.com/Cognisant-llc/sublime-claude-code",
-			"labels": ["ai", "claude", "diff"],
+			"labels": [
+				"ai",
+				"claude",
+				"diff"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4107",
@@ -1421,7 +1731,10 @@
 		{
 			"name": "Claudette",
 			"details": "https://github.com/barryceelen/Claudette",
-			"labels": ["ai", "claude"],
+			"labels": [
+				"ai",
+				"claude"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4075",
@@ -1432,7 +1745,9 @@
 		{
 			"name": "Clay Schubiner Color Schemes",
 			"details": "https://github.com/cschubiner/Sublime-Text-2-Color-Schemes",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1443,7 +1758,10 @@
 		{
 			"name": "clean-css",
 			"details": "https://github.com/1000ch/Sublime-clean-css",
-			"labels": ["formatting", "css"],
+			"labels": [
+				"formatting",
+				"css"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1494,7 +1812,9 @@
 		{
 			"name": "Click",
 			"details": "https://github.com/drbarrett/click-sublime",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1515,7 +1835,9 @@
 		{
 			"name": "Clickability Velocity",
 			"details": "https://github.com/user004/Clickability-Velocity",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1546,7 +1868,12 @@
 		{
 			"name": "ClickableRequires",
 			"details": "https://github.com/hajnalben/ClickableRequires",
-			"labels": ["require", "node", "javascript", "js"],
+			"labels": [
+				"require",
+				"node",
+				"javascript",
+				"js"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1596,7 +1923,9 @@
 		{
 			"name": "CLIPS Rules",
 			"details": "https://github.com/psicomante/CLIPS-sublime",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1607,7 +1936,12 @@
 		{
 			"name": "Clojure Sublimed",
 			"details": "https://github.com/tonsky/Clojure-Sublimed",
-			"labels": ["clojure", "repl", "nrepl", "language syntax"],
+			"labels": [
+				"clojure",
+				"repl",
+				"nrepl",
+				"language syntax"
+			],
 			"donate": "https://www.patreon.com/tonsky",
 			"releases": [
 				{
@@ -1629,7 +1963,9 @@
 		{
 			"name": "CloneFile",
 			"details": "https://github.com/shagabutdinov/sublime-clone-file",
-			"labels": ["sublime-enhanced"],
+			"labels": [
+				"sublime-enhanced"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1720,7 +2056,9 @@
 		{
 			"name": "CloudFormation Validation",
 			"details": "https://github.com/Coolstuff14/sublime-cloudformationbuild",
-			"labels": ["build system"],
+			"labels": [
+				"build system"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1741,7 +2079,11 @@
 		{
 			"name": "CloudWatchLogs",
 			"details": "https://github.com/rnhurt/SublimeText-CloudWatchLogs",
-			"labels": ["aws", "cloudwatch", "logs"],
+			"labels": [
+				"aws",
+				"cloudwatch",
+				"logs"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1752,7 +2094,9 @@
 		{
 			"name": "CMake",
 			"details": "https://github.com/zyxar/Sublime-CMakeLists",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3154",
@@ -1763,7 +2107,10 @@
 		{
 			"name": "CMakeBuilder",
 			"details": "https://github.com/rwols/CMakeBuilder",
-			"labels": ["workflow", "build system"],
+			"labels": [
+				"workflow",
+				"build system"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1774,7 +2121,11 @@
 		{
 			"name": "CMakeEditor",
 			"details": "https://github.com/thenewvu/SublimeCMakeEditor",
-			"labels": ["auto-complete", "documentation", "language syntax"],
+			"labels": [
+				"auto-complete",
+				"documentation",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1785,7 +2136,10 @@
 		{
 			"name": "CMakeFormat",
 			"details": "https://github.com/jasjuang/sublime_cmake_format",
-			"labels": ["formatting", "cmake"],
+			"labels": [
+				"formatting",
+				"cmake"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1826,7 +2180,9 @@
 		{
 			"name": "Cml Syntax Highlight",
 			"details": "https://github.com/quyatong/cml-syntax-highlight",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1837,7 +2193,9 @@
 		{
 			"name": "CMS Made Simple Snippets",
 			"details": "https://github.com/bbonora/SublimeCMSMadeSimple",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1848,7 +2206,10 @@
 		{
 			"name": "CMSSWLookup",
 			"details": "https://github.com/riga/CMSSWLookup",
-			"labels": ["cern", "cmssw"],
+			"labels": [
+				"cern",
+				"cmssw"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1859,7 +2220,11 @@
 		{
 			"name": "CNC BoschRexroth MTX",
 			"details": "https://github.com/deathaxe/sublime-mtx",
-			"labels": ["completions", "language syntax", "snippets"],
+			"labels": [
+				"completions",
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -1870,7 +2235,11 @@
 		{
 			"name": "CNC Sinumerik",
 			"details": "https://github.com/deathaxe/sublime-s840d",
-			"labels": ["completions", "language syntax", "snippets"],
+			"labels": [
+				"completions",
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "3153 - 3300",
@@ -1885,7 +2254,9 @@
 		{
 			"name": "coala",
 			"details": "https://github.com/coala/coala-sublime",
-			"labels": ["linting"],
+			"labels": [
+				"linting"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -1906,7 +2277,10 @@
 		{
 			"name": "COBOL Syntax",
 			"details": "https://bitbucket.org/bitlang/sublime_cobol",
-			"labels": ["language syntax", "completions"],
+			"labels": [
+				"language syntax",
+				"completions"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1917,7 +2291,9 @@
 		{
 			"name": "Cobra",
 			"details": "https://github.com/virakal/SublimeCobra",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1928,7 +2304,9 @@
 		{
 			"name": "Coco R Syntax Highlighting",
 			"details": "https://github.com/mschoebel/cocosyntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1939,7 +2317,9 @@
 		{
 			"name": "Coconut",
 			"details": "https://github.com/evhub/sublime-coconut",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1950,7 +2330,9 @@
 		{
 			"name": "Cocos Creator Snippet",
 			"details": "https://github.com/lyzz0612/Cocos-Creator-Snippet",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1961,7 +2343,9 @@
 		{
 			"name": "cocos2d lua api",
 			"details": "https://github.com/06wj/cocos2d_lua_snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -1972,7 +2356,9 @@
 		{
 			"name": "cocos2dx js api",
 			"details": "https://github.com/wshxbqq/cocos2dx-js-completions",
-			"labels": ["completions"],
+			"labels": [
+				"completions"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1983,7 +2369,9 @@
 		{
 			"name": "CocosRubyEditor",
 			"details": "https://github.com/tkyaji/CocosRubyEditor",
-			"labels": ["auto-complete"],
+			"labels": [
+				"auto-complete"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -1995,7 +2383,9 @@
 			"name": "Coda Redux",
 			"details": "https://github.com/ojbaeza/Coda-Redux",
 			"author": "ojbaeza",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2015,7 +2405,9 @@
 		},
 		{
 			"name": "Coddy Colour Scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"details": "https://github.com/codetickdev/coddy",
 			"releases": [
 				{
@@ -2027,7 +2419,12 @@
 		{
 			"name": "Code Cast",
 			"details": "https://github.com/mraiur/CodeCast",
-			"labels": ["code", "cast", "share", "codecast"],
+			"labels": [
+				"code",
+				"cast",
+				"share",
+				"codecast"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2038,7 +2435,9 @@
 		{
 			"name": "Code Champion",
 			"details": "https://github.com/Atbox/CodeChampion",
-			"labels": ["utilities"],
+			"labels": [
+				"utilities"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2133,7 +2532,12 @@
 		{
 			"name": "CodeContinue",
 			"details": "https://github.com/kXborg/codeContinue",
-			"labels": ["auto-complete", "ai", "llm", "code completion"],
+			"labels": [
+				"auto-complete",
+				"ai",
+				"llm",
+				"code completion"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4000",
@@ -2144,7 +2548,11 @@
 		{
 			"name": "CodeDrafts",
 			"details": "https://github.com/subeeshb/codedrafts_sublime_plugin",
-			"labels": ["code sharing", "snippets", "utilities"],
+			"labels": [
+				"code sharing",
+				"snippets",
+				"utilities"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2155,7 +2563,9 @@
 		{
 			"name": "CodeFall Color Scheme",
 			"details": "https://github.com/EncryptEx/CodeFall",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2179,7 +2589,17 @@
 		{
 			"name": "CodeFormatter",
 			"details": "https://github.com/akalongman/sublimetext-codeformatter",
-			"labels": ["formatting", "utilities", "php", "css", "javascript", "html", "python", "automation", "indentation"],
+			"labels": [
+				"formatting",
+				"utilities",
+				"php",
+				"css",
+				"javascript",
+				"html",
+				"python",
+				"automation",
+				"indentation"
+			],
 			"author": "Avtandil Kikabidze aka LONGMAN",
 			"releases": [
 				{
@@ -2195,7 +2615,9 @@
 		{
 			"name": "CodeIgniter 2 ModelController",
 			"details": "https://github.com/todorowww/st2-snippet-ci2-mc",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2206,7 +2628,9 @@
 		{
 			"name": "CodeIgniter 3 Snippets",
 			"details": "https://github.com/agoenks29D/Codeigniter-3-Sublime-Snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2217,7 +2641,9 @@
 		{
 			"name": "CodeIgniter 4 Snippets",
 			"details": "https://github.com/mpmont/ci4-snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2238,7 +2664,9 @@
 		{
 			"name": "CodeIgniter Snippets",
 			"details": "https://github.com/mpmont/ci-snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2260,7 +2688,10 @@
 			"name": "Codeivate",
 			"details": "https://github.com/codeivate/codeivate-st",
 			"issues": "https://codeivate.userecho.com/",
-			"labels": ["code sharing", "analytics"],
+			"labels": [
+				"code sharing",
+				"analytics"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -2275,7 +2706,10 @@
 		{
 			"name": "CodeKit",
 			"details": "https://github.com/ManxStef/sublime-codekit",
-			"labels": ["auto-complete", "language syntax"],
+			"labels": [
+				"auto-complete",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2286,7 +2720,10 @@
 		{
 			"name": "CodeKit Commands",
 			"details": "https://github.com/subhaze/sublime_codekit",
-			"labels": ["workflow", "build system"],
+			"labels": [
+				"workflow",
+				"build system"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2298,7 +2735,12 @@
 		{
 			"name": "CodeLines",
 			"details": "https://github.com/absop/ST-CodeLines",
-			"labels": ["analytics", "statistics", "status bar", "utilities"],
+			"labels": [
+				"analytics",
+				"statistics",
+				"status bar",
+				"utilities"
+			],
 			"author": "absop",
 			"releases": [
 				{
@@ -2320,7 +2762,11 @@
 		{
 			"name": "Codemp",
 			"details": "https://github.com/hexedtech/codemp-sublime",
-			"labels": ["collaborative", "crdt", "editing"],
+			"labels": [
+				"collaborative",
+				"crdt",
+				"editing"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4000",
@@ -2331,7 +2777,9 @@
 		{
 			"name": "CodePresenter",
 			"details": "https://github.com/fwph/codepresenter",
-			"labels": ["presentation"],
+			"labels": [
+				"presentation"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2342,7 +2790,9 @@
 		{
 			"name": "CodeRunner - Color Scheme",
 			"details": "https://github.com/hanakin/CodeRunner-sublime-theme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2374,11 +2824,18 @@
 			"name": "CodeShot",
 			"details": "https://github.com/yasinahmed/CodeShot",
 			"author": "Yasin Jagral",
-			"labels": ["code", "screenshot", "clipboard", "windows"],
+			"labels": [
+				"code",
+				"screenshot",
+				"clipboard",
+				"windows"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4107",
-					"platforms": ["windows"],
+					"platforms": [
+						"windows"
+					],
 					"tags": true
 				}
 			]
@@ -2386,7 +2843,10 @@
 		{
 			"name": "CodeStats",
 			"details": "https://github.com/code-stats/code-stats-sublime",
-			"labels": ["analytics", "statistics"],
+			"labels": [
+				"analytics",
+				"statistics"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2417,7 +2877,13 @@
 		{
 			"name": "CodeTime",
 			"details": "https://github.com/swdotcom/swdc-sublime",
-			"labels": ["utilities", "status bar", "javascript", "google", "productivity"],
+			"labels": [
+				"utilities",
+				"status bar",
+				"javascript",
+				"google",
+				"productivity"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2429,7 +2895,9 @@
 			"name": "CodeTimeTracker",
 			"details": "https://github.com/barretov/CodeTimeTracker",
 			"author": "Victor Eduardo Barreto",
-			"labels": ["time tracker"],
+			"labels": [
+				"time tracker"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2451,8 +2919,20 @@
 		{
 			"name": "Codex",
 			"details": "https://github.com/yaroslavyaroslav/CodexSublime",
-			"previous_names": ["CodexAI"],
-			"labels": ["mcp", "agents", "openai", "gemini", "claude", "anthropic", "llm", "deepseek", "qwen"],
+			"previous_names": [
+				"CodexAI"
+			],
+			"labels": [
+				"mcp",
+				"agents",
+				"openai",
+				"gemini",
+				"claude",
+				"anthropic",
+				"llm",
+				"deepseek",
+				"qwen"
+			],
 			"donate": "https://github.com/sponsors/yaroslavyaroslav",
 			"releases": [
 				{
@@ -2474,7 +2954,9 @@
 		{
 			"name": "Coffee Color Scheme",
 			"details": "https://github.com/watergear/sublime-coffee-color-scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2505,7 +2987,9 @@
 		{
 			"name": "CoffeeAngular Syntax",
 			"details": "https://github.com/ukyo/CoffeeAngular.tmLanguage",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2536,8 +3020,15 @@
 		{
 			"name": "CoffeeScript",
 			"details": "https://github.com/SublimeText/CoffeeScript",
-			"labels": ["language syntax", "linting", "snippets", "coffeescript"],
-			"previous_names": ["Better CoffeeScript"],
+			"labels": [
+				"language syntax",
+				"linting",
+				"snippets",
+				"coffeescript"
+			],
+			"previous_names": [
+				"Better CoffeeScript"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4143",
@@ -2556,7 +3047,9 @@
 		{
 			"name": "CoffeeScript Ddry Snippets",
 			"details": "https://github.com/ddry/ddry-sublime-coffee-snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2576,7 +3069,9 @@
 		},
 		{
 			"details": "https://github.com/jisaacks/CoffeeScriptHaml",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2586,7 +3081,11 @@
 		},
 		{
 			"details": "https://github.com/SublimeText/Coi",
-			"labels": ["completions", "language syntax", "snippets"],
+			"labels": [
+				"completions",
+				"language syntax",
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4180",
@@ -2597,7 +3096,15 @@
 		{
 			"name": "ColdBox Platform",
 			"details": "https://github.com/ColdBox/coldbox-sublime",
-			"labels": ["snippets", "coldbox", "cachebox", "logbox", "testbox", "wirebox", "boxlang"],
+			"labels": [
+				"snippets",
+				"coldbox",
+				"cachebox",
+				"logbox",
+				"testbox",
+				"wirebox",
+				"boxlang"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2607,7 +3114,9 @@
 		},
 		{
 			"details": "https://github.com/SublimeText/ColdFusion",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -2631,7 +3140,9 @@
 			"releases": [
 				{
 					"sublime_text": ">=3084",
-					"platforms": ["linux"],
+					"platforms": [
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -2649,7 +3160,9 @@
 		{
 			"name": "ColobotSyntaxHighlighting",
 			"details": "https://github.com/MrSimbax/sublime-colobot-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3084",
@@ -2660,8 +3173,17 @@
 		{
 			"name": "Color Highlight",
 			"details": "https://github.com/SublimeText/ColorHighlight",
-			"author": ["Kronuz"],
-			"labels": ["color", "highlight", "highlighter", "hex", "rgb", "hsl"],
+			"author": [
+				"Kronuz"
+			],
+			"labels": [
+				"color",
+				"highlight",
+				"highlighter",
+				"hex",
+				"rgb",
+				"hsl"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2682,7 +3204,9 @@
 		{
 			"name": "Color Scheme - Baara Dark",
 			"details": "https://github.com/jobedom/sublime-baara-dark",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2693,7 +3217,9 @@
 		{
 			"name": "Color Scheme - Bass",
 			"details": "https://github.com/53v3n3d4/Color-Scheme-Bass",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2704,7 +3230,9 @@
 		{
 			"name": "Color Scheme - Chromodynamics",
 			"details": "https://github.com/MagicStack/Chromodynamics",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2715,7 +3243,9 @@
 		{
 			"name": "Color Scheme - CoderPad",
 			"details": "https://github.com/marwan37/CoderPad-Color-Scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2726,7 +3256,9 @@
 		{
 			"name": "Color Scheme - Creamy",
 			"details": "https://github.com/quimcalpe/sublime-creamy-theme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2737,7 +3269,9 @@
 		{
 			"name": "Color Scheme - Dracula Neue",
 			"details": "https://github.com/facelessuser/sublime-dracula-scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2748,7 +3282,9 @@
 		{
 			"name": "Color Scheme - Dusk",
 			"details": "https://github.com/geekpradd/Dusk-Color-Scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2759,7 +3295,9 @@
 		{
 			"name": "Color Scheme - Eazy Light",
 			"details": "https://github.com/txdm/Eazy-Light",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2770,7 +3308,9 @@
 		{
 			"name": "Color Scheme - Eggplant Parm",
 			"details": "https://github.com/mimshwright/sublime-eggplant-parm",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2781,7 +3321,9 @@
 		{
 			"name": "Color Scheme - Frontend Delight",
 			"details": "https://github.com/bernatfortet/sublime-frontend-delight",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2792,7 +3334,9 @@
 		{
 			"name": "Color Scheme - Gerbus",
 			"details": "https://github.com/gerbus/sublime-color-scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3152",
@@ -2803,7 +3347,10 @@
 		{
 			"name": "Color Scheme - Gray Matter",
 			"details": "https://github.com/philipbelesky/Gray-Matter",
-			"labels": ["color scheme", "markdown"],
+			"labels": [
+				"color scheme",
+				"markdown"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2814,7 +3361,10 @@
 		{
 			"name": "Color Scheme - Legacy",
 			"details": "https://github.com/SublimeText/LegacyColorSchemes",
-			"labels": ["color scheme", "legacy"],
+			"labels": [
+				"color scheme",
+				"legacy"
+			],
 			"releases": [
 				{
 					"sublime_text": ">3131",
@@ -2826,7 +3376,9 @@
 			"name": "Color Scheme - Pastels UI",
 			"author": "E1ectroN",
 			"details": "https://github.com/solo-s/sublime-pastels-ui",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2838,7 +3390,9 @@
 			"name": "Color Scheme - Rainbow",
 			"details": "https://github.com/pradyun/Sublime-Rainbow-ColorScheme",
 			"author": "Pradyun Gedam",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2849,7 +3403,9 @@
 		{
 			"name": "Color Scheme - Sleeplessmind",
 			"details": "https://github.com/godbout/sleeplessmind-color-scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2860,7 +3416,9 @@
 		{
 			"name": "Color Scheme - Spectral",
 			"details": "https://github.com/blackdaw/spectral.tmTheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2872,7 +3430,9 @@
 			"name": "Color Scheme - Thunderstorm",
 			"details": "https://github.com/39digits/thunderstorm-sublime-theme",
 			"author": "Christopher Hamilton",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2883,7 +3443,9 @@
 		{
 			"name": "Color Scheme - Vintage Terminal",
 			"details": "https://github.com/tonylegrone/terminal-sublime",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2914,7 +3476,9 @@
 		{
 			"name": "Color Schemes by carlcalderon",
 			"details": "https://github.com/carlcalderon/sublime-color-schemes",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -2925,7 +3489,9 @@
 		{
 			"name": "Colorcoder",
 			"details": "https://github.com/vprimachenko/Sublime-Colorcoder",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -2940,8 +3506,18 @@
 		{
 			"details": "https://github.com/braver/ColorConverter",
 			"donate": "https://ko-fi.com/koenlageveen",
-			"labels": ["css", "colors", "utilities"],
-			"previous_names": ["Color Convert", "CSS Color Converter", "Hex to HSL Color Converter", "Hex to RGB Converter", "Hex-to-RGBA"],
+			"labels": [
+				"css",
+				"colors",
+				"utilities"
+			],
+			"previous_names": [
+				"Color Convert",
+				"CSS Color Converter",
+				"Hex to HSL Color Converter",
+				"Hex to RGB Converter",
+				"Hex-to-RGBA"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4143",
@@ -2953,7 +3529,11 @@
 			"name": "Colored Comments",
 			"details": "https://github.com/TheSecEng/ColoredComments",
 			"author": "Terminal / TheSecEng",
-			"labels": ["colorization", "colors", "comments"],
+			"labels": [
+				"colorization",
+				"colors",
+				"comments"
+			],
 			"releases": [
 				{
 					"sublime_text": "3170 - 3999",
@@ -2967,7 +3547,11 @@
 		},
 		{
 			"details": "https://github.com/facelessuser/ColorHelper",
-			"labels": ["color", "preview", "utilities"],
+			"labels": [
+				"color",
+				"preview",
+				"utilities"
+			],
 			"releases": [
 				{
 					"sublime_text": "3170 - 3999",
@@ -2986,7 +3570,11 @@
 		{
 			"details": "https://github.com/braver/ColorHints",
 			"donate": "https://ko-fi.com/koenlageveen",
-			"labels": ["css", "colors", "utilities"],
+			"labels": [
+				"css",
+				"colors",
+				"utilities"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3200",
@@ -3026,9 +3614,14 @@
 		},
 		{
 			"name": "ColorSchemeUnit",
-			"previous_names": ["color_scheme_unit"],
+			"previous_names": [
+				"color_scheme_unit"
+			],
 			"details": "https://github.com/gerardroche/sublime-color-scheme-unit",
-			"labels": ["color scheme", "testing"],
+			"labels": [
+				"color scheme",
+				"testing"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3039,7 +3632,9 @@
 		{
 			"name": "Colorsublime",
 			"details": "https://github.com/Colorsublime/Colorsublime-Plugin",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3060,7 +3655,15 @@
 		{
 			"name": "Colour Complete",
 			"details": "https://github.com/jbrooksuk/ColourComplete",
-			"labels": ["colour", "color", "complete", "css", "scss", "sass", "less"],
+			"labels": [
+				"colour",
+				"color",
+				"complete",
+				"css",
+				"scss",
+				"sass",
+				"less"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3086,7 +3689,9 @@
 		{
 			"name": "Columbus Syntax",
 			"details": "https://bitbucket.org/canlustenberger/brainwarecolumbus",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -3137,7 +3742,10 @@
 		{
 			"name": "CombineMediaQueries",
 			"details": "https://github.com/astronaughts/SublimeCombineMediaQueries",
-			"labels": ["css", "media query"],
+			"labels": [
+				"css",
+				"media query"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3158,7 +3766,9 @@
 		{
 			"name": "Combyne",
 			"details": "https://github.com/kadamwhite/Sublime-Combyne",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3209,7 +3819,11 @@
 		{
 			"name": "CommandsBrowser",
 			"details": "https://github.com/Sublime-Instincts/CommandsBrowser",
-			"labels": ["commands", "plugin/package commands", "browser"],
+			"labels": [
+				"commands",
+				"plugin/package commands",
+				"browser"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4121",
@@ -3220,7 +3834,10 @@
 		{
 			"name": "Comment Marks",
 			"details": "https://github.com/maegul/comment_marks",
-			"labels": ["comments", "code navigation"],
+			"labels": [
+				"comments",
+				"code navigation"
+			],
 			"author": "maegul",
 			"releases": [
 				{
@@ -3231,7 +3848,9 @@
 		},
 		{
 			"details": "https://github.com/ajayexpert/comment-snippet",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3241,7 +3860,9 @@
 		},
 		{
 			"details": "https://github.com/hachesilva/Comment-Snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3272,7 +3893,10 @@
 			"name": "CommentFold",
 			"description": "Gives an overview of your comments by folding all other code",
 			"details": "https://github.com/mapsiter/CommentFold",
-			"labels": ["utilities", "code navigation"],
+			"labels": [
+				"utilities",
+				"code navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3293,7 +3917,9 @@
 		{
 			"name": "Comments-only Color Scheme",
 			"details": "https://github.com/cyevgeniy/sublime-comments-only",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3304,7 +3930,11 @@
 		{
 			"name": "Commitment",
 			"details": "https://github.com/janraasch/sublimetext-commitment",
-			"labels": ["vcs", "git", "fun"],
+			"labels": [
+				"vcs",
+				"git",
+				"fun"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3324,7 +3954,11 @@
 		{
 			"name": "Compare Side-By-Side",
 			"details": "https://github.com/kaste/Compare-Side-By-Side",
-			"labels": ["diff", "compare", "comparison"],
+			"labels": [
+				"diff",
+				"compare",
+				"comparison"
+			],
 			"releases": [
 				{
 					"sublime_text": "<4000",
@@ -3339,7 +3973,13 @@
 		{
 			"details": "https://github.com/nexional/CompareBuff",
 			"author": "VK",
-			"labels": ["compare", "comparison", "beyond compare", "diff", "buffer"],
+			"labels": [
+				"compare",
+				"comparison",
+				"beyond compare",
+				"diff",
+				"buffer"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3349,7 +3989,13 @@
 		},
 		{
 			"details": "https://github.com/xalteropsx/CompareHistory",
-			"labels": ["diff", "compare", "comparison", "version-history", "side-by-side"],
+			"labels": [
+				"diff",
+				"compare",
+				"comparison",
+				"version-history",
+				"side-by-side"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3143",
@@ -3361,7 +4007,17 @@
 			"name": "Compass",
 			"details": "https://github.com/whatwedo/sublime-text-compass",
 			"author": "whatwedo",
-			"labels": ["compass", "scss", "sass", "css", "precompiler", "watch", "css3", "build system", "minify"],
+			"labels": [
+				"compass",
+				"scss",
+				"sass",
+				"css",
+				"precompiler",
+				"watch",
+				"css3",
+				"build system",
+				"minify"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3373,7 +4029,9 @@
 			"name": "Compass Navigator",
 			"details": "https://github.com/kapitanluffy/sublime-compass",
 			"donate": "https://github.com/sponsors/kapitanluffy",
-			"labels": ["code navigation"],
+			"labels": [
+				"code navigation"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4000",
@@ -3395,7 +4053,10 @@
 		{
 			"name": "Competitive Programming Lite",
 			"details": "https://github.com/JameelKaisar/Competitive-Programming-Lite",
-			"labels": ["competitive programming", "competitive coding"],
+			"labels": [
+				"competitive programming",
+				"competitive coding"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4107",
@@ -3419,7 +4080,10 @@
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx", "linux"],
+					"platforms": [
+						"osx",
+						"linux"
+					],
 					"tags": true
 				}
 			]
@@ -3438,7 +4102,12 @@
 			"name": "CompletePHP",
 			"details": "https://github.com/desean1625/CompletePHP",
 			"author": "Desean1625",
-			"labels": ["auto-complete", "completions", "documentation", "php"],
+			"labels": [
+				"auto-complete",
+				"completions",
+				"documentation",
+				"php"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3449,7 +4118,10 @@
 		{
 			"name": "CompleteXmlTag",
 			"details": "https://github.com/neothenil/sublimetext_complete_xml_tag",
-			"labels": ["formatting", "xml"],
+			"labels": [
+				"formatting",
+				"xml"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3461,7 +4133,10 @@
 			"name": "ComplexBuild",
 			"details": "https://github.com/lucteo/ComplexBuild",
 			"author": "lucteo",
-			"labels": ["build system", "workflow"],
+			"labels": [
+				"build system",
+				"workflow"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3483,7 +4158,10 @@
 			"name": "ComposerPackageInfo",
 			"details": "https://github.com/gh640/SublimeComposerPackageInfo",
 			"author": "Goto Hayato",
-			"labels": ["php", "composer"],
+			"labels": [
+				"php",
+				"composer"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3124",
@@ -3494,7 +4172,11 @@
 		{
 			"name": "Compressor",
 			"details": "https://github.com/joernhees/sublime-compressor",
-			"labels": ["compression", "decompress", "gzip"],
+			"labels": [
+				"compression",
+				"decompress",
+				"gzip"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3505,7 +4187,9 @@
 		{
 			"name": "ComputerCraft Package",
 			"details": "https://github.com/benanders/ST2-ComputerCraft-Package",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3516,7 +4200,16 @@
 		{
 			"name": "Conda",
 			"details": "https://github.com/mandeep/sublime-text-conda",
-			"labels": ["build system", "snippets", "utilities", "python", "search", "anaconda", "miniconda", "conda"],
+			"labels": [
+				"build system",
+				"snippets",
+				"utilities",
+				"python",
+				"search",
+				"anaconda",
+				"miniconda",
+				"conda"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3527,7 +4220,11 @@
 		{
 			"name": "Conditional ColorSchemes",
 			"details": "https://github.com/enteleform-releases/SublimeText--Conditional-ColorSchemes",
-			"labels": ["color scheme", "automation", "automate"],
+			"labels": [
+				"color scheme",
+				"automation",
+				"automate"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3538,11 +4235,18 @@
 		{
 			"name": "ConEmuOpen",
 			"details": "https://github.com/tianjianchn/Sublime_ConEmuOpen",
-			"labels": ["conemu", "cmd", "windows", "cmd here"],
+			"labels": [
+				"conemu",
+				"cmd",
+				"windows",
+				"cmd here"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["windows"],
+					"platforms": [
+						"windows"
+					],
 					"tags": true
 				}
 			]
@@ -3550,7 +4254,9 @@
 		{
 			"name": "Configify",
 			"details": "https://github.com/loganhasson/configify",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3572,7 +4278,9 @@
 		{
 			"name": "Conky.tmLanguage",
 			"details": "https://github.com/oliverseal/Conky.tmLanguage",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3583,7 +4291,9 @@
 		{
 			"name": "CoNLL-U",
 			"details": "https://github.com/stephsamson/CoNLL-U.tmLanguage",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3595,7 +4305,12 @@
 			"name": "Console Exec",
 			"details": "https://github.com/joeyespo/sublimetext-console-exec",
 			"author": "Joe Esposito",
-			"labels": ["build system", "console", "terminal", "utilities"],
+			"labels": [
+				"build system",
+				"console",
+				"terminal",
+				"utilities"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3607,7 +4322,15 @@
 			"name": "Console Wrap",
 			"details": "https://github.com/unknownuser88/consolewrap",
 			"author": "David Bekoyan",
-			"labels": ["auto-complete", "completions", "debug", "console", "logs", "output", "javascript"],
+			"labels": [
+				"auto-complete",
+				"completions",
+				"debug",
+				"console",
+				"logs",
+				"output",
+				"javascript"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3617,7 +4340,13 @@
 		},
 		{
 			"details": "https://github.com/abathur/constellation",
-			"labels": ["project", "workspace", "utilities", "session", "group"],
+			"labels": [
+				"project",
+				"workspace",
+				"utilities",
+				"session",
+				"group"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3161",
@@ -3628,7 +4357,16 @@
 		{
 			"name": "Contao Front-End Snippets",
 			"details": "https://github.com/marcobiedermann/sublime-contao-front-end-snippets",
-			"labels": ["snippets", "cms", "contao", "css", "less", "sass", "scss", "stylus"],
+			"labels": [
+				"snippets",
+				"cms",
+				"contao",
+				"css",
+				"less",
+				"sass",
+				"scss",
+				"stylus"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3639,7 +4377,10 @@
 		{
 			"name": "Context",
 			"details": "https://github.com/shagabutdinov/sublime-context",
-			"labels": ["sublime-enhanced", "utilities"],
+			"labels": [
+				"sublime-enhanced",
+				"utilities"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3670,7 +4411,9 @@
 		{
 			"name": "Continuous Merge",
 			"details": "https://github.com/vim-zz/sublime-cm-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4075",
@@ -3691,7 +4434,9 @@
 			"name": "ConvCalculate",
 			"details": "https://github.com/convictss/ConvSublimeCalculate",
 			"author": "Convict Yellow (Kailian.Huang)",
-			"labels": ["calculator"],
+			"labels": [
+				"calculator"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3712,7 +4457,11 @@
 		{
 			"name": "ConvertFullHalfWidth",
 			"details": "https://github.com/naoyukik/SublimeConvertFullHalfWidth",
-			"labels": ["japanese", "zenkaku", "hankaku"],
+			"labels": [
+				"japanese",
+				"zenkaku",
+				"hankaku"
+			],
 			"releases": [
 				{
 					"sublime_text": ">3000",
@@ -3733,7 +4482,9 @@
 		{
 			"name": "CookLang",
 			"details": "https://github.com/cooklang/CookSublime",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3744,7 +4495,9 @@
 		{
 			"name": "Cool",
 			"details": "https://github.com/princjef/sublime-cool-highlighter",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3756,7 +4509,9 @@
 			"name": "Cool & Clear - Color Scheme",
 			"details": "https://github.com/Doodpants/Cool-and-Clear-Color-Scheme",
 			"author": "Karl von Laudermann",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3170",
@@ -3777,7 +4532,10 @@
 		{
 			"name": "CoolFormat",
 			"details": "https://github.com/edokan/Sublime-CoolFormat",
-			"labels": ["formatting", "tidy"],
+			"labels": [
+				"formatting",
+				"tidy"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3788,11 +4546,17 @@
 		{
 			"name": "Copy as HTML",
 			"details": "https://github.com/liulex/CopyAsHtml",
-			"labels": ["copy", "html", "clipboard"],
+			"labels": [
+				"copy",
+				"html",
+				"clipboard"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["windows"],
+					"platforms": [
+						"windows"
+					],
 					"tags": true
 				}
 			]
@@ -3810,7 +4574,9 @@
 		{
 			"name": "Copy Code Snippet",
 			"details": "https://github.com/socsieng/sublime-copy-code-snippet",
-			"labels": ["copy"],
+			"labels": [
+				"copy"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3821,7 +4587,14 @@
 		{
 			"name": "Copy Cut and Paste Lines",
 			"details": "https://github.com/alanlynn/sublime-copy-cut-paste-lines",
-			"labels": ["text manipulation", "clipboard", "copy", "cut", "paste", "duplicate"],
+			"labels": [
+				"text manipulation",
+				"clipboard",
+				"copy",
+				"cut",
+				"paste",
+				"duplicate"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3832,7 +4605,9 @@
 		{
 			"name": "Copy File Name",
 			"details": "https://github.com/nwjlyons/copy-file-name",
-			"previous_names": ["copy-file-name"],
+			"previous_names": [
+				"copy-file-name"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -3970,7 +4745,9 @@
 		{
 			"name": "Coq",
 			"details": "https://github.com/whitequark/Sublime-Coq",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -3981,7 +4758,9 @@
 		{
 			"name": "Core dna snippets",
 			"details": "https://github.com/bwiredagency/core_dna_snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -3992,7 +4771,9 @@
 		{
 			"name": "Coreboot syntax",
 			"details": "https://github.com/coreboot/sublime-text-coreboot-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -4003,7 +4784,9 @@
 		{
 			"name": "CoreBuilder",
 			"details": "https://github.com/rodrigoangeline/CoreBuilder_SublimeText",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4014,11 +4797,16 @@
 		{
 			"name": "Corona Editor",
 			"details": "https://github.com/coronalabs/CoronaSDK-SublimeText",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
-					"platforms": ["osx", "windows"],
+					"platforms": [
+						"osx",
+						"windows"
+					],
 					"tags": true
 				}
 			]
@@ -4026,7 +4814,9 @@
 		{
 			"name": "Cortex",
 			"details": "https://github.com/cortoproject/CortexIDE",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4037,7 +4827,9 @@
 		{
 			"name": "Cosmos Scope",
 			"details": "https://github.com/KristianHolsheimer/cosmos_scope_sublime",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -4058,7 +4850,10 @@
 		{
 			"name": "Cottle",
 			"details": "https://github.com/SublimeText/Cottle",
-			"labels": ["completions", "language syntax"],
+			"labels": [
+				"completions",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3143",
@@ -4089,7 +4884,10 @@
 		{
 			"name": "CP Parser",
 			"details": "https://github.com/hritikchaudhary/CPParser",
-			"labels": ["competitive-programming", "parser"],
+			"labels": [
+				"competitive-programming",
+				"parser"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4100,7 +4898,10 @@
 		{
 			"name": "cp2k-syntax",
 			"details": "https://github.com/nholmber/cp2k-syntax",
-			"labels": ["language syntax", "linting"],
+			"labels": [
+				"language syntax",
+				"linting"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3084",
@@ -4131,7 +4932,13 @@
 		{
 			"name": "CppFastOlympicCoding",
 			"details": "https://github.com/Jatana/FastOlympicCoding",
-			"labels": ["auto-complete", "linting", "snippets", "testing", "c++"],
+			"labels": [
+				"auto-complete",
+				"linting",
+				"snippets",
+				"testing",
+				"c++"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -4140,9 +4947,34 @@
 			]
 		},
 		{
+			"name": "cph-by-chenkx",
+			"description": "Sublime Text plugin for competitive programming with cph-ng style verdict display, similar to FastOlympicCoding. Built-in Competitive Companion browser extension support.",
+			"details": "https://github.com/chenmoulaile/cph-by-chenkx",
+			"homepage": "https://github.com/chenmoulaile/cph-by-chenkx",
+			"author": "chenkx",
+			"issues": "https://github.com/chenmoulaile/cph-by-chenkx/issues",
+			"labels": [
+				"competitive programming",
+				"c++",
+				"testing",
+				"competitive companion"
+			],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "CppToolkit",
 			"details": "https://github.com/mccartnm/CppToolkitSublimeText",
-			"labels": ["auto-complete", "autodeclare", "refactor", "c++"],
+			"labels": [
+				"auto-complete",
+				"autodeclare",
+				"refactor",
+				"c++"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -4153,11 +4985,17 @@
 		{
 			"name": "CPrettify",
 			"details": "https://github.com/aghontpi/CPrettify-Sublime-text-3",
-			"labels": ["c", "prettify", "cprettify"],
+			"labels": [
+				"c",
+				"prettify",
+				"cprettify"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
-					"platforms": ["windows"],
+					"platforms": [
+						"windows"
+					],
 					"tags": true
 				}
 			]
@@ -4165,7 +5003,11 @@
 		{
 			"name": "CQ Clientlibs Syntax Highlight",
 			"details": "https://github.com/diestrin/cq-clienltib-sublime-language",
-			"labels": ["cq", "clientlib", "language syntax"],
+			"labels": [
+				"cq",
+				"clientlib",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4186,7 +5028,9 @@
 		{
 			"name": "Crackshell",
 			"details": "https://github.com/Crackshell/sublime-text",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3103",
@@ -4197,7 +5041,9 @@
 		{
 			"name": "Craft-Twig",
 			"details": "https://github.com/BarrelStrength/Craft-Twig.tmbundle",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4208,7 +5054,9 @@
 		{
 			"name": "CrafterSama Scheme",
 			"details": "https://github.com/CrafterSama/CrafterSama-Scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4219,7 +5067,10 @@
 		{
 			"name": "Crates",
 			"details": "https://github.com/Kerollmops/sublime-crates",
-			"labels": ["completions", "rust"],
+			"labels": [
+				"completions",
+				"rust"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -4230,7 +5081,10 @@
 		{
 			"name": "Create Backup Copy",
 			"details": "https://github.com/glutanimate/sublime-create-backup-copy",
-			"labels": ["backup", "file creation"],
+			"labels": [
+				"backup",
+				"file creation"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -4241,7 +5095,9 @@
 		{
 			"name": "Create Js Completions",
 			"details": "https://github.com/wshxbqq/createjs-completions",
-			"labels": ["completions"],
+			"labels": [
+				"completions"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4262,7 +5118,10 @@
 		{
 			"author": "Tomas Barry",
 			"name": "Create WebP Image",
-			"labels": ["webp", "cwebp"],
+			"labels": [
+				"webp",
+				"cwebp"
+			],
 			"details": "https://github.com/TomasBarry/Sublime-create-webp-image",
 			"releases": [
 				{
@@ -4284,7 +5143,10 @@
 		{
 			"name": "Creeper Reverse Polish Language",
 			"details": "https://github.com/KubeRoot/Sublime-CRPL",
-			"labels": ["language syntax", "completions"],
+			"labels": [
+				"language syntax",
+				"completions"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -4294,7 +5156,9 @@
 		},
 		{
 			"details": "https://github.com/Siddley/Creole",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4305,7 +5169,9 @@
 		{
 			"name": "Crestron",
 			"details": "https://github.com/amclain/sublime-crestron",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4315,7 +5181,9 @@
 		},
 		{
 			"name": "Criollo Color Scheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"details": "https://github.com/aranajhonny/criollo",
 			"releases": [
 				{
@@ -4327,7 +5195,9 @@
 		{
 			"name": "Cristina Color Scheme",
 			"details": "https://github.com/edgarMejia/Cristina-ColorScheme",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4349,7 +5219,12 @@
 		{
 			"name": "Crontab",
 			"details": "https://github.com/michaelblyons/SublimeSyntax-Crontab",
-			"labels": ["language syntax", "completions", "cron", "crontab"],
+			"labels": [
+				"language syntax",
+				"completions",
+				"cron",
+				"crontab"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -4393,7 +5268,10 @@
 		{
 			"name": "Crystal",
 			"details": "https://github.com/crystal-lang-tools/sublime-crystal",
-			"labels": ["crystal", "language syntax"],
+			"labels": [
+				"crystal",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4424,7 +5302,9 @@
 		{
 			"name": "CSharpier",
 			"details": "https://github.com/mkonstapel/sublime-text-csharpier-plugin",
-			"labels": ["formatting"],
+			"labels": [
+				"formatting"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4435,12 +5315,18 @@
 		{
 			"name": "cslint",
 			"details": "https://github.com/cslint/sublime-cslint",
-			"labels": ["code style", "formatting", "linting"],
+			"labels": [
+				"code style",
+				"formatting",
+				"linting"
+			],
 			"author": "molee1905",
 			"releases": [
 				{
 					"sublime_text": ">=3124",
-					"platforms": ["osx"],
+					"platforms": [
+						"osx"
+					],
 					"tags": true
 				}
 			]
@@ -4448,7 +5334,11 @@
 		{
 			"name": "CSON Converter",
 			"details": "https://github.com/idleberg/sublime-cson-converter",
-			"labels": ["converter", "cson", "json"],
+			"labels": [
+				"converter",
+				"cson",
+				"json"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -4459,7 +5349,13 @@
 		{
 			"name": "CsoundSyntax",
 			"details": "https://github.com/nikhilsinghmus/CsoundST3",
-			"labels": ["csound", "music", "sound", "audio", "language syntax"],
+			"labels": [
+				"csound",
+				"music",
+				"sound",
+				"audio",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -4470,7 +5366,9 @@
 		{
 			"name": "CSPM",
 			"details": "https://github.com/cspm/SublimeCSPM",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -4491,7 +5389,10 @@
 		{
 			"name": "CSS Colors",
 			"details": "https://github.com/idleberg/CSS-Colors",
-			"labels": ["snippets", "css"],
+			"labels": [
+				"snippets",
+				"css"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4502,7 +5403,12 @@
 		{
 			"name": "CSS Comments",
 			"details": "https://github.com/brenopolanski/css-comments-sublime-snippets",
-			"labels": ["snippets", "css", "comments", "idiomatic-css"],
+			"labels": [
+				"snippets",
+				"css",
+				"comments",
+				"idiomatic-css"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4523,7 +5429,11 @@
 		{
 			"name": "CSS Extended Completions",
 			"details": "https://github.com/subhaze/CSS-Extended",
-			"labels": ["auto-complete", "snippets", "css"],
+			"labels": [
+				"auto-complete",
+				"snippets",
+				"css"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4534,7 +5444,10 @@
 		{
 			"name": "CSS Format",
 			"details": "https://github.com/mutian/Sublime-CSS-Format",
-			"labels": ["formatting", "css"],
+			"labels": [
+				"formatting",
+				"css"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4545,7 +5458,10 @@
 		{
 			"name": "CSS Grid Snippets",
 			"details": "https://github.com/antenando/css-grid-sublime-snippets",
-			"labels": ["snippets", "css"],
+			"labels": [
+				"snippets",
+				"css"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4556,7 +5472,11 @@
 		{
 			"name": "CSS Intellisense",
 			"details": "https://github.com/id-sakurata/CSS-Intellisense",
-			"labels": ["auto-complete", "snippets", "css"],
+			"labels": [
+				"auto-complete",
+				"snippets",
+				"css"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4567,7 +5487,11 @@
 		{
 			"name": "CSS Less(ish)",
 			"details": "https://github.com/kizza/CSS-Less-ish",
-			"labels": ["formatting", "css", "precompiler"],
+			"labels": [
+				"formatting",
+				"css",
+				"precompiler"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4578,7 +5502,9 @@
 		{
 			"name": "CSS Media Query Snippets",
 			"details": "https://github.com/davezatch/Media-Query-Snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4589,7 +5515,9 @@
 		{
 			"name": "CSS Primer",
 			"details": "https://github.com/vaicine/sublimetext-css-primer",
-			"labels": ["file creation"],
+			"labels": [
+				"file creation"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4620,7 +5548,9 @@
 		{
 			"name": "CSS Snippets",
 			"details": "https://github.com/joshnh/CSS-Snippets",
-			"labels": ["snippets"],
+			"labels": [
+				"snippets"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4661,7 +5591,12 @@
 		{
 			"name": "CSS-On-Diet",
 			"details": "https://github.com/wyderkat/css-on-diet--sublime-text",
-			"labels": ["build system", "language syntax", "css", "preprocessor"],
+			"labels": [
+				"build system",
+				"language syntax",
+				"css",
+				"preprocessor"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4672,7 +5607,13 @@
 		{
 			"name": "CSS3",
 			"details": "https://github.com/ryboe/CSS3",
-			"labels": ["auto-complete", "completions", "language syntax", "linting", "reset"],
+			"labels": [
+				"auto-complete",
+				"completions",
+				"language syntax",
+				"linting",
+				"reset"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3000",
@@ -4682,7 +5623,9 @@
 		},
 		{
 			"name": "CSScheme",
-			"labels": ["color scheme editing"],
+			"labels": [
+				"color scheme editing"
+			],
 			"details": "https://github.com/FichteFoll/CSScheme",
 			"releases": [
 				{
@@ -4756,7 +5699,9 @@
 		{
 			"name": "CSSLint",
 			"details": "https://github.com/austinhappel/sublime-csslint",
-			"labels": ["linting"],
+			"labels": [
+				"linting"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4791,7 +5736,10 @@
 		{
 			"name": "CSSO",
 			"details": "https://github.com/1000ch/Sublime-csso",
-			"labels": ["formatting", "css"],
+			"labels": [
+				"formatting",
+				"css"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4866,7 +5814,9 @@
 		{
 			"name": "Ctranslator tool",
 			"details": "https://github.com/smallevilbeast/ctranslator-sublime3-plugin",
-			"labels": ["utilities"],
+			"labels": [
+				"utilities"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3070",
@@ -4877,7 +5827,9 @@
 		{
 			"name": "Cube2Media Color Scheme",
 			"details": "https://github.com/electricgraffitti/sublime-theme-Cube2",
-			"labels": ["color scheme"],
+			"labels": [
+				"color scheme"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4888,7 +5840,9 @@
 		{
 			"name": "Cubescript Syntax Highlighting",
 			"details": "https://github.com/srbs/cubescript-syntax-sublime",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4899,7 +5853,10 @@
 		{
 			"name": "Cucumber",
 			"details": "https://github.com/drewda/cucumber-sublime-bundle",
-			"labels": ["language syntax", "cucumber"],
+			"labels": [
+				"language syntax",
+				"cucumber"
+			],
 			"releases": [
 				{
 					"sublime_text": "<3000",
@@ -4924,7 +5881,10 @@
 		{
 			"name": "Cucumber Snippets e Highlight em Inglês",
 			"details": "https://github.com/RobertoPegoraro/cucumber-snippets-highlight-english",
-			"labels": ["language syntax", "cucumber"],
+			"labels": [
+				"language syntax",
+				"cucumber"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -4935,7 +5895,10 @@
 		{
 			"name": "Cucumber Snippets e Highlight em Português",
 			"details": "https://github.com/RobertoPegoraro/cucumber-snippets-highlight-portugues",
-			"labels": ["language syntax", "cucumber"],
+			"labels": [
+				"language syntax",
+				"cucumber"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4956,7 +5919,9 @@
 		{
 			"name": "CUDA C++",
 			"details": "https://github.com/harrism/sublimetext-cuda-cpp",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4967,7 +5932,9 @@
 		{
 			"name": "CUDA Snippets",
 			"details": "https://github.com/LitLeo/CUDA-Sublime-Text-Snippets",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -4978,7 +5945,9 @@
 		{
 			"name": "CUE",
 			"details": "https://gitlab.com/patopest/Sublime-Text-Cuelang-Syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"author": "patopesto",
 			"releases": [
 				{
@@ -4990,7 +5959,9 @@
 		{
 			"name": "CUE Sheet",
 			"details": "https://github.com/relikd/CUE-Sheet_sublime",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -5001,7 +5972,9 @@
 		{
 			"name": "Cuneiform",
 			"details": "https://github.com/joergen7/cuneiform-sublime",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -5012,7 +5985,9 @@
 		{
 			"name": "Cup",
 			"details": "https://github.com/alin23/Cup",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -5023,7 +5998,9 @@
 		{
 			"name": "Curly Syntax Definition",
 			"details": "https://github.com/medcat/CurlySyntaxDefinition",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -5034,7 +6011,10 @@
 		{
 			"name": "Curry Syntax Highlighting",
 			"details": "https://github.com/jpsikorra/curry_syntax_highlight",
-			"labels": ["curry", "language syntax"],
+			"labels": [
+				"curry",
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -5124,7 +6104,10 @@
 		{
 			"name": "CWL Syntax Highlighting",
 			"details": "https://github.com/manabuishii/sublime-cwl-syntax",
-			"labels": ["language syntax", "cwl"],
+			"labels": [
+				"language syntax",
+				"cwl"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -5156,7 +6139,9 @@
 		{
 			"name": "Cypher",
 			"details": "https://github.com/fulguritude/cypher-sublime-syntax",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=3092",
@@ -5167,7 +6152,9 @@
 		{
 			"name": "Cython",
 			"details": "https://github.com/NotSqrt/sublime-cython",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",
@@ -5178,7 +6165,9 @@
 		{
 			"name": "Cython+",
 			"details": "https://github.com/petervaro/python",
-			"labels": ["language syntax"],
+			"labels": [
+				"language syntax"
+			],
 			"releases": [
 				{
 					"sublime_text": "*",


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I am the package author and/or maintainer.
- [x] I have read [the docs](https://docs.sublimetext.io/guide/package-control/submitting.html).
- [x] I have tagged a release with a [semver](https://semver.org) version number (v1.0.6).
- [x] My package repo has a description and a README describing what it is for and how to use it.
- [ ] My package does not add context menu entries. *
- [ ] My package does not add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it does not also add a color scheme. ***
- [x] I use [.gitattributes](https://git-scm.com/docs/gitattributes#_export_ignore) to exclude files from the package.

My package is a Sublime Text competitive programming plugin similar to CppFastOlympicCoding with cph-ng style verdict display and built-in Competitive Companion browser extension support.

It is similar to [CppFastOlympicCoding](https://github.com/Jatana/FastOlympicCoding) but should still be added because it adds cph-ng style verdict color badges (AC/WA/TLE/RE/etc.), a detail panel (similar to cph-ng) showing input/expected/actual/stderr, built-in Competitive Companion listener (port 12345), and a Chinese/English language toggle.

Context menu entries (Context.sublime-menu) and key bindings (Default (Windows/OSX/Linux).sublime-keymap) are included for convenience (run tests, import tests, start stress test), following the same pattern as CppFastOlympicCoding.
