### PR TITLE
Add MOOSE package

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -2594,6 +2594,17 @@
 			]
 		},
 		{
+			"name": "MOOSE",
+			"details": "https://github.com/elcarrillo/moose-sublime",
+			"labels": ["language syntax"],
+			"releases": [
+				{
+					"sublime_text": ">=3092",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "More Layouts",
 			"details": "https://github.com/unknownuser88/morelayouts",
 			"author": "David Bekoyan",


### PR DESCRIPTION
Adds MOOSE to Package Control.

MOOSE provides Sublime Text syntax highlighting and editor integration for MOOSE input files.

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package provides language support for MOOSE input files, including syntax highlighting and integration with MOOSE's language server.

There are no packages like it in Package Control.