### PR TITLE
Add MCP Commander

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -1236,6 +1236,18 @@
 			]
 		},
 		{
+			"name": "MCP Commander",
+			"description": "Turns Sublime Text into an MCP server that an external AI agent (e.g. Claude Code) can directly control: read cursor context, edit files, navigate, run builds, and evaluate Python in ST's runtime, while the user watches changes happen live.",
+			"details": "https://github.com/dpc00/sublime-mcp",
+			"labels": ["ai", "mcp"],
+			"releases": [
+				{
+					"sublime_text": "*",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "MCPHelper",
 			"description": "Connects to a local Model Context Protocol (MCP) server for AI-powered code generation, review, refactoring, and translation using OpenAI or Gemini.",
 			"author": "David Donohue",


### PR DESCRIPTION
## Package details

**Name:** MCP Commander
**Repo:** https://github.com/dpc00/sublime-mcp
**Labels:** ai, mcp

## Description

MCP (Model Context Protocol) server for Sublime Text 4. Turns Sublime Text
into an MCP server that an external AI agent (e.g. Claude Code) can
directly control: read cursor context, edit files, navigate, run builds,
and evaluate Python in ST's runtime, while the user watches changes
happen live. The agent is the client; ST is the controlled environment.

This differs from AI Bridge / MCPHelper (MCP *clients* that connect ST
outward to an AI service) and MCPServer (a generic MCP server that
doesn't surface ST's own API as callable tools): this package exposes
Sublime's internal Python API directly as MCP tools, at a level of
granularity none of the three offer.

## History

This package was listed here briefly in June 2026 (PR #9447) and pulled
two weeks later at my request (PR #9458) while I was still deciding
whether to commit to maintaining it. Since then it's had continued,
active development (v1.5-1.7: native tab/sheet APIs, diagnostics
tooling, a real diff-review workflow) and I'm resubmitting because I
intend to keep maintaining it, not on a whim.

## Checklist

- [x] I'm the package's author and/or maintainer.
- [x] I have read the docs.
- [x] I have tagged a release with a semver version number (v1.7.1).
- [x] My package repo has a description and a README describing what
      it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings (Default (Windows/OSX/Linux)
      keymaps exist but are empty/reserved, not bound).
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and
      the command palette, and open in split view.
- [x] My package doesn't add a color scheme.
- [x] I use .gitattributes to exclude dev-only files (tests, tools,
      skills, the separately-published proxy package sources) from
      the installed package.