### PR TITLE
Add AutoOpenReadme

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -2575,6 +2575,17 @@
 			]
 		},
 		{
+			"name": "AutoOpenReadme",
+			"details": "https://github.com/noahcoad/SublimeAutoOpenReadme",
+			"labels": ["utilities", "file navigation", "project"],
+			"releases": [
+				{
+					"sublime_text": ">=3000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "AutoPEP8",
 			"details": "https://github.com/wistful/SublimeAutoPEP8",
 			"labels": ["formatting", "linting"],


### PR DESCRIPTION
Automatically opens the README.md file on opening a folder. Configurable to look for other files and in other folders, like a notes.txt file or for these in docs/ or wiki/ folders.

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is ... a resubmission of [#9221](https://github.com/sublimehq/package_control_channel/pull/9221) (this supersedes #9221), which you approved and then closed for inactivity with "We'll re-open when you get around to it!" --
I've opened a fresh PR instead of asking for a reopen because I took your naming advice and the package
name changed, so the old PR's title and diff no longer match.

Renamed **Auto Open Notes -> AutoOpenReadme**, per your note that "'auto open notes' didn't
immediately mean anything to me, whereas 'auto open readme' kind of does". 

Also addressed since [#9221](https://github.com/sublimehq/package_control_channel/pull/9221):

- Fixed the leaked file handle FichteFoll flagged back on #7748 -- the `.sublime.autoopen` list is read
  inside a `with open(...)` block now.
- Settings are in the command palette as well as the menu, and open in split view via `edit_settings`.
  There are no commands and no key bindings -- it's a plain `EventListener`, nothing to bind.
- Dropped a snarky tabs-vs-spaces comment from the source

Tagged `v0.1.2`. Repo: https://github.com/noahcoad/SublimeAutoOpenReadme

There are no packages like it in Package Control. The nearest names are *Open Folder* (reveals a folder
in the OS file manager) and *ProjectFiles* (a file navigator) -- neither opens a readme when you open a
folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
