### PR TITLE
Google Spell Check: switch to tagged releases

### DIFF
--- a/repository/g.json
+++ b/repository/g.json
@@ -1550,12 +1550,8 @@
 			"details": "https://github.com/noahcoad/google-spell-check",
 			"releases": [
 				{
-					"sublime_text": ">=3000",
-					"branch": "st3"
-				},
-				{
-					"sublime_text": "<3000",
-					"branch": "st2"
+					"sublime_text": ">=4107",
+					"tags": true
 				}
 			]
 		},


### PR DESCRIPTION
Follow-up to #9501, which you closed — sorry for the delay. This is the `"tags": true` switch
you asked for, plus the bot's review items from that PR.

Google Spell Check has been in the channel since 2013; this only updates its entry.

The entry is now a single release:

```json
{ "sublime_text": ">=4107", "tags": true }
```

`>=4107` rather than `>=3000` because the plugin uses `html.unescape`, which needs the 3.8
plugin host. The `st2` / `st3` branch entries are gone — the package is maintained on `master`
and released as tags (`v2.0.0`, `v2.1.0`, `v2.1.1`).

Everything `st_package_reviewer` flagged on #9501 is fixed in `v2.1.1`:

- **`ctrl+alt+g` had no context.** It's no longer shipped at all. `Default.sublime-keymap`
  carries it commented out, reachable from *Preferences → Package Settings → Google Spell
  Check → Key Bindings* and from the palette as *Preferences: Google Spell Check Key
  Bindings*, both via `edit_settings`. Documented in the README, and `messages/2.1.0.txt`
  tells existing users how to get the binding back.
- **No `Main.sublime-menu`.** Added.
- **No `LICENSE`.** Added, MIT.

Two things from the checklist below worth calling out:

- The package does add a **context menu** entry. I kept it — it's the most natural way to run
  this — but made it conditional per the footnote: `is_visible()` only shows it when there's a
  word or selection to check.
- Auditing for this turned up a real bug: `.python-version` was in `.gitignore`, so the file
  existed locally but had never been committed. An installed copy would have run in the 3.3
  plugin host and died on `html.unescape`. It's tracked now.

- [x] I'm the package's author and/or maintainer.
- [x] I have read the docs.
- [x] I have tagged a release with a semver version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [ ] My package doesn't add context menu entries. — it does, one entry, conditional (see above)
- [x] My package doesn't add key bindings.
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. — n/a
- [x] I use `.gitattributes` to exclude files from the package: images, test files, sublime-project/workspace.
