### PR TITLE
Open URL: repo renamed to noahcoad/SublimeOpenUrl

### DIFF
--- a/repository/o.json
+++ b/repository/o.json
@@ -659,7 +659,7 @@
 		},
 		{
 			"name": "Open URL",
-			"details": "https://github.com/noahcoad/open-url",
+			"details": "https://github.com/noahcoad/SublimeOpenUrl",
 			"labels": ["open paths", "open files", "shortcut", "power user", "web search", "url"],
 			"releases": [
 				{


### PR DESCRIPTION
I renamed my repository from `noahcoad/open-url` to `noahcoad/SublimeOpenUrl`, to match the naming of my other Sublime packages. This updates the `details` URL to match.

- **Package name is unchanged** (`Open URL`), so nothing changes for installed users.
- The old URL currently 301-redirects, so installs keep working either way — but I'd like the entry to be accurate, and I'd rather not have the channel depend on a redirect that I could break later by putting a placeholder repo at the old path.
- Release bands and tags are untouched. Latest tag is `3.1.1`.

No other change in this PR.