### PR TITLE
Add Markdown Nav

### DIFF
--- a/repository/m.json
+++ b/repository/m.json
@@ -553,6 +553,17 @@
 			]
 		},
 		{
+			"name": "Markdown Nav",
+			"details": "https://github.com/noahcoad/SublimeMarkdownNav",
+			"labels": ["markdown", "code navigation", "search"],
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "Markdown Numbered Headers",
 			"details": "https://github.com/weituotian/md_numbered_headers",
 			"labels": ["markdown", "headers", "numbered headers"],


### PR DESCRIPTION
- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries.
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme.
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

[1]: https://docs.sublimetext.io/guide/package-control/submitting.html
[2]: https://semver.org
[3]: https://www.git-scm.com/docs/gitattributes#_export_ignore

My package is ... two Command Palette commands for getting around a long markdown document: one
walks the header tree a level at a time, the other finds tagged lines.

**Jump to Header** descends the outline instead of listing every header at once. The first panel
shows the top level of the document; picking a header that has sub-headers opens the next level down
with a `(jump here)` entry on top; picking a leaf header jumps straight there. The panel also
reopens on your last pick, with the row on the path to it pre-highlighted, so re-running the command
returns you to where you were. That's the part I built it for -- in a file with a few hundred
headers, a flat symbol list means fuzzy-typing the same section name over and over.

**Find Tag** collects lines carrying a `keyword: text` prefix or a `#hashtag`, then offers a tag
picker followed by a match picker. A tag on a header or on a line of nothing but hashtags refers to
the whole section, so it jumps to the section; anywhere else it refers to just that line. Match
labels have the tag stripped out so the list reads as content. The whole convention is documented in
the README, and the one part that varies by taste -- the character pattern for a tag name, which is
lowercase-only by default -- is a setting.

Sublime Text 4 only (build 4107+), because it runs in the 3.8 plugin host.

My package is similar to a few things, but nothing that overlaps much:

- **InlineOutline** is the closest on the header side and is genuinely nice -- fuzzy-search or
  arrow-walk a symbol list inline, `esc` restores the cursor and viewport. It's a flat list of all
  symbols, though: no level-by-level descent and no memory of the last pick.
- **MarkdownEditing** contributes header symbols so the built-in Goto Symbol (`⌘R`) lists headings,
  and can fold them. Also flat, and it's a large editing package rather than a navigation one.
- **Table of comments** does have hierarchical headings with a quick panel, but they're headings
  written inside *code comments* with `>`/`>>` prefixes, not markdown `#` headers, and it also
  writes a table of contents into the document.
- **MarkdownTOC**, **Markdown Table of Contents** and **Markdown Numbered Headers** all *write*
  TOCs or numbering into the file; none of them navigate.
- On the tag side I couldn't find anything. The other "tag" packages in the channel are HTML/XML tag
  wrappers or ctags integrations.

It should still be added because the header-tree descent with a remembered position, and tag-based
jumping, aren't available in any of the above.
