### PR TITLE
Add ACP plugin

### DIFF
--- a/repository/a.json
+++ b/repository/a.json
@@ -209,6 +209,17 @@
 			]
 		},
 		{
+			"name": "ACP",
+			"details": "https://github.com/debjan/sublime-acp",
+			"labels": ["ai", "agent", "chat", "acp"],
+			"releases": [
+				{
+					"sublime_text": ">=4050",
+					"tags": true
+				}
+			]
+		},
+		{
 			"name": "ACTG",
 			"details": "https://github.com/hackerfriendly/ACTG",
 			"labels": ["language syntax"],


### PR DESCRIPTION
<!--
Please have patience, we usually need a few weeks to get around to reviewing your submission. 
To help us do so, please provide some information about your package:
-->

- [x] I'm the package's author and/or maintainer.
- [x] I have read [the docs][1].
- [x] I have tagged a release with a [semver][2] version number.
- [x] My package repo has a description and a README describing what it's for and how to use it.
- [x] My package doesn't add context menu entries. *
- [x] My package doesn't add key bindings. **
- [x] Any commands are available via the command palette.
- [x] Preferences and keybindings (if any) are listed in the menu and the command palette, and open in split view.
- [x] If my package is a syntax it doesn't also add a color scheme. ***
- [x] I use [.gitattributes][3] to exclude files from the package: images, test files, sublime-project/workspace.

ACP client plugin for Sublime Text editor

There are no packages like it in Package Control.